### PR TITLE
Fixed issue where get-only properties not always populated

### DIFF
--- a/ModelBuilder.UnitTests/ModelBuilder.UnitTests.csproj
+++ b/ModelBuilder.UnitTests/ModelBuilder.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
+  <Import Project="..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -39,16 +39,16 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=4.18.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.18.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.19.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.19.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="NSubstitute, Version=1.10.0.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
-      <HintPath>..\packages\NSubstitute.1.10.0.0\lib\net45\NSubstitute.dll</HintPath>
+    <Reference Include="NSubstitute, Version=2.0.2.0, Culture=neutral, PublicKeyToken=92dd2e9066daa5ca, processorArchitecture=MSIL">
+      <HintPath>..\packages\NSubstitute.2.0.2\lib\net45\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -62,19 +62,19 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
+      <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>
@@ -130,6 +130,9 @@
       <DependentUpon>Models.cs</DependentUpon>
     </Compile>
     <Compile Include="ReadOnlyParent.cs">
+      <DependentUpon>Models.cs</DependentUpon>
+    </Compile>
+    <Compile Include="SelfReferrer.cs">
       <DependentUpon>Models.cs</DependentUpon>
     </Compile>
     <Compile Include="TestCompilerModule.cs" />
@@ -289,8 +292,8 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
     <Error Condition="!Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets'))" />
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
   </Target>
   <Import Project="..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets" Condition="Exists('..\packages\GitVersionTask.3.6.5\build\dotnet\GitVersionTask.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/ModelBuilder.UnitTests/ReadOnlyParent.cs
+++ b/ModelBuilder.UnitTests/ReadOnlyParent.cs
@@ -11,6 +11,8 @@
             RestrictedPeople = EmptySet();
             AssignablePeople = new List<Person>();
             People = new Collection<Person>();
+            ReadOnlyPerson = new Person();
+            PrivateValue = 0;
         }
 
         private IEnumerable<Person> EmptySet()
@@ -23,6 +25,9 @@
         public Company Company { get; private set; }
 
         public ICollection<Person> People { get; private set; }
+        public int PrivateValue { get; }
+
+        public Person ReadOnlyPerson { get; }
 
         public IEnumerable<Person> RestrictedPeople { get; private set; }
 

--- a/ModelBuilder.UnitTests/SelfReferrer.cs
+++ b/ModelBuilder.UnitTests/SelfReferrer.cs
@@ -1,0 +1,10 @@
+﻿namespace ModelBuilder.UnitTests
+{
+    using System;
+
+    public class SelfReferrer
+    {
+        public Guid Id { get; set; }
+        public SelfReferrer Self { get; set; }
+    }
+}

--- a/ModelBuilder.UnitTests/packages.config
+++ b/ModelBuilder.UnitTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="4.18.0" targetFramework="net461" />
+  <package id="FluentAssertions" version="4.19.0" targetFramework="net461" />
   <package id="GitVersionTask" version="3.6.5" targetFramework="net461" developmentDependency="true" />
-  <package id="NSubstitute" version="1.10.0.0" targetFramework="net461" />
-  <package id="xunit" version="2.1.0" targetFramework="net461" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net461" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net461" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net461" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net461" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net461" />
-  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net461" />
+  <package id="NSubstitute" version="2.0.2" targetFramework="net461" />
+  <package id="xunit" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/ModelBuilder/ModelBuilder.csproj
+++ b/ModelBuilder/ModelBuilder.csproj
@@ -152,6 +152,9 @@
     <Compile Include="RandomGeneratorExtensions.cs">
       <DependentUpon>Extensions.cs</DependentUpon>
     </Compile>
+    <Compile Include="ReflectionExtensions.cs">
+      <DependentUpon>Extensions.cs</DependentUpon>
+    </Compile>
     <Compile Include="RelativeValueGenerator.cs">
       <DependentUpon>IValueGenerator.cs</DependentUpon>
     </Compile>

--- a/ModelBuilder/ReflectionExtensions.cs
+++ b/ModelBuilder/ReflectionExtensions.cs
@@ -1,0 +1,53 @@
+﻿namespace ModelBuilder
+{
+    using System.Diagnostics;
+    using System.Reflection;
+
+    internal static class ReflectionExtensions
+    {
+        public static bool CanPopulate(this PropertyInfo propertyInfo)
+        {
+            var setMethod = propertyInfo.GetSetMethod();
+
+            if (setMethod != null)
+            {
+                if (setMethod.IsStatic)
+                {
+                    // Static properties are not supported
+                    return false;
+                }
+
+                // This is a publically settable instance property
+                // Against this we can assign both value and reference types
+                return true;
+            }
+
+            // There is no set method. This is a read-only property
+            var getMethod = propertyInfo.GetGetMethod();
+
+            Debug.Assert(
+                getMethod != null,
+                "This is a private property which should not have been included in the set of properties to evaluate.");
+
+            if (getMethod.IsStatic)
+            {
+                // Static methods are not supported
+                return false;
+            }
+
+            if (getMethod.ReturnType.IsValueType)
+            {
+                // We can't populate a value type via a get method
+                return false;
+            }
+
+            if (getMethod.ReturnType == typeof(string))
+            {
+                // We can't populate a string type via a get method because strings are immutable
+                return false;
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Fixed issue where get-only properties returning instance values were not populated.

Fixed issue where populating nested objects did not execute post build actions.
Updated population logging to encompass typeCreator.Populate and post build actions.

Fixes #39