### PR TITLE
Updated EnumerableTypeCreator to support more types

### DIFF
--- a/ModelBuilder.Synchronous.UnitTests/ModelBuilder.Synchronous.UnitTests.csproj
+++ b/ModelBuilder.Synchronous.UnitTests/ModelBuilder.Synchronous.UnitTests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="nsubstitute" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/ModelBuilder.UnitTests/DefaultTypeResolverTests.cs
+++ b/ModelBuilder.UnitTests/DefaultTypeResolverTests.cs
@@ -3,7 +3,6 @@
     using System;
     using System.Collections;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.IO;
     using FluentAssertions;
     using ModelBuilder.UnitTests.Models;
@@ -25,9 +24,9 @@
         [InlineData(typeof(ICollection), typeof(List<object>))]
         [InlineData(typeof(IList), typeof(List<object>))]
         [InlineData(typeof(IEnumerable<Person>), typeof(List<Person>))]
-        [InlineData(typeof(ICollection<Person>), typeof(Collection<Person>))]
+        [InlineData(typeof(ICollection<Person>), typeof(List<Person>))]
         [InlineData(typeof(IList<Person>), typeof(List<Person>))]
-        [InlineData(typeof(IReadOnlyCollection<Person>), typeof(ReadOnlyCollection<Person>))]
+        [InlineData(typeof(IReadOnlyCollection<Person>), typeof(List<Person>))]
         [InlineData(typeof(IDictionary<Guid, Person>), typeof(Dictionary<Guid, Person>))]
         public void CanCreateEnumerableTypesFromInterfacesWithExpectedResolutionPriority(Type requestedType,
             Type expectedType)

--- a/ModelBuilder.UnitTests/ModelBuilder.UnitTests.csproj
+++ b/ModelBuilder.UnitTests/ModelBuilder.UnitTests.csproj
@@ -11,9 +11,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NodaTime" Version="2.4.7" />
+    <PackageReference Include="NodaTime" Version="2.4.8" />
     <PackageReference Include="nsubstitute" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/ModelBuilder.UnitTests/Models/IInterfaceCollection.cs
+++ b/ModelBuilder.UnitTests/Models/IInterfaceCollection.cs
@@ -1,0 +1,8 @@
+﻿namespace ModelBuilder.UnitTests.Models
+{
+    using System.Collections.Generic;
+
+    public interface IInterfaceCollection<T> : IList<T>
+    {
+    }
+}

--- a/ModelBuilder.UnitTests/Models/MultipleGenericArguments.cs
+++ b/ModelBuilder.UnitTests/Models/MultipleGenericArguments.cs
@@ -1,0 +1,6 @@
+﻿namespace ModelBuilder.UnitTests.Models
+{
+    public class MultipleGenericArguments<TKey, TValue>
+    {
+    }
+}

--- a/ModelBuilder.UnitTests/Scenarios/ScenarioTests.cs
+++ b/ModelBuilder.UnitTests/Scenarios/ScenarioTests.cs
@@ -69,8 +69,34 @@
             Guid.Parse(actual.Address.AddressLine1).Should().NotBeEmpty();
         }
 
+        [Theory]
+        [InlineData(typeof(IEnumerable<string>))]
+        [InlineData(typeof(ICollection<string>))]
+        [InlineData(typeof(Collection<string>))]
+        [InlineData(typeof(IList<string>))]
+        [InlineData(typeof(List<string>))]
+        [InlineData(typeof(LinkedList<string>))]
+        [InlineData(typeof(InheritedGenericCollection))]
+        [InlineData(typeof(HashSet<string>))]
+        [InlineData(typeof(IList<KeyValuePair<string, Guid>>))]
+        [InlineData(typeof(List<KeyValuePair<string, Guid>>))]
+        [InlineData(typeof(List<MultipleGenericArguments<string, Guid>>))]
+        [InlineData(typeof(IList<MultipleGenericArguments<string, Guid>>))]
+        [InlineData(typeof(Collection<KeyValuePair<string, Guid>>))]
+        [InlineData(typeof(ICollection<KeyValuePair<string, Guid>>))]
+        [InlineData(typeof(IReadOnlyCollection<int>))]
+        [InlineData(typeof(IReadOnlyList<int>))]
+        [InlineData(typeof(IDictionary<string, Person>))]
+        [InlineData(typeof(Dictionary<string, Person>))]
+        public void CanCreateEnumerableTypes(Type type)
+        {
+            var actual = Model.Create(type);
+
+            actual.As<IEnumerable>().Should().NotBeEmpty();
+        }
+
         [Fact]
-        public void CanCreateEnumerableTypes()
+        public void CanCreateInstanceWithEnumerablePropertyTypes()
         {
             var actual = Model.Create<EnumerableParent>();
 
@@ -79,22 +105,6 @@
             actual.InterfaceCollection.Should().NotBeEmpty();
             actual.InterfaceList.Should().NotBeEmpty();
             actual.List.Should().NotBeEmpty();
-        }
-
-        [Theory]
-        [InlineData(typeof(IEnumerable))]
-        [InlineData(typeof(ICollection))]
-        [InlineData(typeof(IList))]
-        [InlineData(typeof(IEnumerable<Person>))]
-        [InlineData(typeof(ICollection<Person>))]
-        [InlineData(typeof(IList<Person>))]
-        [InlineData(typeof(IReadOnlyCollection<Person>))]
-        [InlineData(typeof(IDictionary<Guid, Person>))]
-        public void CanCreateEnumerableTypesFromInterfaces(Type type)
-        {
-            var actual = Model.Create(type);
-
-            actual.As<IEnumerable>().Should().NotBeEmpty();
         }
 
         [Fact]
@@ -110,7 +120,7 @@
         {
             var actual = Model.Create<IReadOnlyCollection<Person>>();
 
-            actual.Should().BeOfType<ReadOnlyCollection<Person>>();
+            actual.Should().BeOfType<List<Person>>();
             actual.Should().NotBeEmpty();
         }
 

--- a/ModelBuilder.UnitTests/TypeCreators/EnumerableTypeCreatorTests.cs
+++ b/ModelBuilder.UnitTests/TypeCreators/EnumerableTypeCreatorTests.cs
@@ -36,12 +36,12 @@
         [InlineData(typeof(string), false)]
         [InlineData(typeof(Stream), false)]
         [InlineData(typeof(int), false)]
-        [InlineData(typeof(ReadOnlyCollection<int>), false)]
-        [InlineData(typeof(IDictionary<string, int>), false)]
+        [InlineData(typeof(int?), false)]
         [InlineData(typeof(Tuple<string, bool>), false)]
+        [InlineData(typeof(ICollection), false)]
+        [InlineData(typeof(IList), false)]
+        [InlineData(typeof(ArrayList), false)]
         [InlineData(typeof(AbstractCollection<Person>), false)]
-        [InlineData(typeof(IReadOnlyCollection<int>), false)]
-        [InlineData(typeof(IReadOnlyList<int>), false)]
         [InlineData(typeof(ArraySegment<string>), false)]
         [InlineData(typeof(IPAddressCollection), false)]
         [InlineData(typeof(GatewayIPAddressInformationCollection), false)]
@@ -50,25 +50,33 @@
         [InlineData(typeof(UnicastIPAddressInformationCollection), false)]
         [InlineData(typeof(Dictionary<,>.KeyCollection), false)]
         [InlineData(typeof(Dictionary<,>.ValueCollection), false)]
-        [InlineData(typeof(Dictionary<string, int>), true)]
+        [InlineData(typeof(ReadOnlyDictionary<string, int>), false)]
+        [InlineData(typeof(ReadOnlyCollection<int>), false)]
         [InlineData(typeof(SortedDictionary<,>.KeyCollection), false)]
         [InlineData(typeof(SortedDictionary<,>.ValueCollection), false)]
+        [InlineData(typeof(IInterfaceCollection<Person>), false)]
         [InlineData(typeof(IEnumerable<string>), true)]
         [InlineData(typeof(ICollection<string>), true)]
-        [InlineData(typeof(Collection<string>), true)]
         [InlineData(typeof(IList<string>), true)]
+        [InlineData(typeof(IList<KeyValuePair<string, Guid>>), true)]
+        [InlineData(typeof(List<KeyValuePair<string, Guid>>), true)]
+        [InlineData(typeof(List<MultipleGenericArguments<string, Guid>>), true)]
+        [InlineData(typeof(IList<MultipleGenericArguments<string, Guid>>), true)]
+        [InlineData(typeof(Collection<KeyValuePair<string, Guid>>), true)]
+        [InlineData(typeof(IReadOnlyCollection<int>), true)]
+        [InlineData(typeof(IReadOnlyList<int>), true)]
+        [InlineData(typeof(IDictionary<string, int>), true)]
+        [InlineData(typeof(Collection<string>), true)]
         [InlineData(typeof(List<string>), true)]
         [InlineData(typeof(HashSet<string>), true)]
+        [InlineData(typeof(Dictionary<string, int>), true)]
         [InlineData(typeof(LinkedList<string>), true)]
         [InlineData(typeof(InheritedGenericCollection), true)]
         public void CanCreateReturnsWhetherTypeIsSupportedTest(Type type, bool supported)
         {
             var executeStrategy = Substitute.For<IExecuteStrategy>();
-            var typeResolver = Substitute.For<ITypeResolver>();
             var configuration = Substitute.For<IBuildConfiguration>();
 
-            configuration.TypeResolver.Returns(typeResolver);
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
             executeStrategy.Configuration.Returns(configuration);
 
             var sut = new EnumerableTypeCreator();
@@ -82,11 +90,8 @@
         public void CanCreateThrowsExceptionWithNullParameter()
         {
             var executeStrategy = Substitute.For<IExecuteStrategy>();
-            var typeResolver = Substitute.For<ITypeResolver>();
             var configuration = Substitute.For<IBuildConfiguration>();
 
-            configuration.TypeResolver.Returns(typeResolver);
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
             executeStrategy.Configuration.Returns(configuration);
 
             var sut = new EnumerableTypeCreator();
@@ -100,11 +105,8 @@
         public void CanCreateThrowsExceptionWithNullProperty()
         {
             var executeStrategy = Substitute.For<IExecuteStrategy>();
-            var typeResolver = Substitute.For<ITypeResolver>();
             var configuration = Substitute.For<IBuildConfiguration>();
 
-            configuration.TypeResolver.Returns(typeResolver);
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
             executeStrategy.Configuration.Returns(configuration);
 
             var sut = new EnumerableTypeCreator();
@@ -118,11 +120,8 @@
         public void CanCreateThrowsExceptionWithNullType()
         {
             var executeStrategy = Substitute.For<IExecuteStrategy>();
-            var typeResolver = Substitute.For<ITypeResolver>();
             var configuration = Substitute.For<IBuildConfiguration>();
 
-            configuration.TypeResolver.Returns(typeResolver);
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
             executeStrategy.Configuration.Returns(configuration);
 
             var sut = new EnumerableTypeCreator();
@@ -161,13 +160,14 @@
         [InlineData(typeof(HashSet<string>), true)]
         [InlineData(typeof(LinkedList<string>), true)]
         [InlineData(typeof(InheritedGenericCollection), true)]
+        [InlineData(typeof(IList<KeyValuePair<string, Guid>>), true)]
+        [InlineData(typeof(List<KeyValuePair<string, Guid>>), true)]
+        [InlineData(typeof(List<MultipleGenericArguments<string, Guid>>), true)]
+        [InlineData(typeof(IList<MultipleGenericArguments<string, Guid>>), true)]
+        [InlineData(typeof(Collection<KeyValuePair<string, Guid>>), true)]
         public void CanPopulateReturnsWhetherTypeIsSupportedTest(Type type, bool supported)
         {
             var configuration = Substitute.For<IBuildConfiguration>();
-            var typeResolver = Substitute.For<ITypeResolver>();
-
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
-            configuration.TypeResolver.Returns(typeResolver);
 
             var sut = new EnumerableTypeCreator();
 
@@ -220,6 +220,28 @@
         }
 
         [Fact]
+        public void CreateByNameThrowsExceptionWithNullExecuteStrategy()
+        {
+            var sut = new EnumerableTypeCreatorWrapper();
+
+            Action action = () => sut.CreateByName(null, typeof(string), null, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void CreateByNameThrowsExceptionWithNullType()
+        {
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+
+            var sut = new EnumerableTypeCreatorWrapper();
+
+            Action action = () => sut.CreateByName(executeStrategy, null, null, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
         public void CreateChildItemThrowsExceptionWithNullExecuteStrategy()
         {
             var person = new Person();
@@ -232,134 +254,56 @@
         }
 
         [Fact]
-        public void CreateDoesNotPopulateList()
+        public void CreateInstanceThrowsExceptionWithNullType()
         {
-            var buildChain = new BuildHistory();
-
             var executeStrategy = Substitute.For<IExecuteStrategy>();
-            var typeResolver = Substitute.For<ITypeResolver>();
-            var configuration = Substitute.For<IBuildConfiguration>();
 
-            configuration.TypeResolver.Returns(typeResolver);
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(configuration);
+            var sut = new EnumerableTypeCreatorWrapper();
 
-            var sut = new IncrementingEnumerableTypeCreator();
+            Action action = () => sut.CreateValue(executeStrategy, null, null, null);
 
-            var result = (IList<int>) sut.Create(executeStrategy, typeof(IList<int>));
-
-            result.Should().BeEmpty();
+            action.Should().Throw<ArgumentNullException>();
         }
 
         [Theory]
-        [InlineData(typeof(Dictionary<string, int>))]
-        [InlineData(typeof(IEnumerable<string>))]
-        [InlineData(typeof(ICollection<string>))]
-        [InlineData(typeof(Collection<string>))]
-        [InlineData(typeof(IList<string>))]
-        [InlineData(typeof(List<string>))]
-        [InlineData(typeof(LinkedList<string>))]
-        [InlineData(typeof(InheritedGenericCollection))]
-        public void CreateReturnsInstanceTest(Type type)
+        [InlineData(typeof(IEnumerable<string>), typeof(List<string>))]
+        [InlineData(typeof(ICollection<string>), typeof(List<string>))]
+        [InlineData(typeof(Collection<string>), typeof(Collection<string>))]
+        [InlineData(typeof(IList<string>), typeof(List<string>))]
+        [InlineData(typeof(List<string>), typeof(List<string>))]
+        [InlineData(typeof(LinkedList<string>), typeof(LinkedList<string>))]
+        [InlineData(typeof(InheritedGenericCollection), typeof(InheritedGenericCollection))]
+        [InlineData(typeof(HashSet<string>), typeof(HashSet<string>))]
+        [InlineData(typeof(IList<KeyValuePair<string, Guid>>), typeof(List<KeyValuePair<string, Guid>>))]
+        [InlineData(typeof(List<KeyValuePair<string, Guid>>), typeof(List<KeyValuePair<string, Guid>>))]
+        [InlineData(typeof(List<MultipleGenericArguments<string, Guid>>),
+            typeof(List<MultipleGenericArguments<string, Guid>>))]
+        [InlineData(typeof(IList<MultipleGenericArguments<string, Guid>>),
+            typeof(List<MultipleGenericArguments<string, Guid>>))]
+        [InlineData(typeof(Collection<KeyValuePair<string, Guid>>), typeof(Collection<KeyValuePair<string, Guid>>))]
+        [InlineData(typeof(ICollection<KeyValuePair<string, Guid>>), typeof(Dictionary<string, Guid>))]
+        [InlineData(typeof(IReadOnlyCollection<int>), typeof(List<int>))]
+        [InlineData(typeof(IReadOnlyList<int>), typeof(List<int>))]
+        [InlineData(typeof(IDictionary<string, Person>), typeof(Dictionary<string, Person>))]
+        [InlineData(typeof(Dictionary<string, Person>), typeof(Dictionary<string, Person>))]
+        public void CreateReturnsInstanceOfMostAppropriateTypeTest(Type requestedType, Type expectedType)
         {
             var buildChain = new BuildHistory();
 
             var executeStrategy = Substitute.For<IExecuteStrategy>();
-            var typeResolver = Substitute.For<ITypeResolver>();
             var configuration = Substitute.For<IBuildConfiguration>();
 
-            configuration.TypeResolver.Returns(typeResolver);
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
             executeStrategy.BuildChain.Returns(buildChain);
             executeStrategy.Configuration.Returns(configuration);
 
             var sut = new EnumerableTypeCreator();
 
-            var actual = sut.Create(executeStrategy, type);
+            var actual = sut.Create(executeStrategy, requestedType);
 
             actual.Should().NotBeNull();
-        }
-
-        [Theory]
-        [InlineData(typeof(IEnumerable<int>))]
-        [InlineData(typeof(ICollection<int>))]
-        [InlineData(typeof(IList<int>))]
-        public void CreateReturnsNewListOfSpecifiedTypeTest(Type targetType)
-        {
-            var buildChain = new BuildHistory();
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-            var typeResolver = Substitute.For<ITypeResolver>();
-            var configuration = Substitute.For<IBuildConfiguration>();
-
-            configuration.TypeResolver.Returns(typeResolver);
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(configuration);
-
-            var sut = new EnumerableTypeCreator();
-
-            var actual = sut.Create(executeStrategy, targetType);
-
-            actual.Should().BeOfType<List<int>>();
-            actual.As<List<int>>().Should().BeEmpty();
-        }
-
-        [Theory]
-        [InlineData(typeof(string), false)]
-        [InlineData(typeof(Stream), false)]
-        [InlineData(typeof(int), false)]
-        [InlineData(typeof(ReadOnlyCollection<int>), false)]
-        [InlineData(typeof(IDictionary<string, int>), false)]
-        [InlineData(typeof(Tuple<string, bool>), false)]
-        [InlineData(typeof(AbstractCollection<Person>), false)]
-        [InlineData(typeof(IReadOnlyCollection<int>), false)]
-        [InlineData(typeof(IReadOnlyList<int>), false)]
-        [InlineData(typeof(ArraySegment<string>), false)]
-        [InlineData(typeof(IPAddressCollection), false)]
-        [InlineData(typeof(GatewayIPAddressInformationCollection), false)]
-        [InlineData(typeof(IPAddressInformationCollection), false)]
-        [InlineData(typeof(MulticastIPAddressInformationCollection), false)]
-        [InlineData(typeof(UnicastIPAddressInformationCollection), false)]
-        [InlineData(typeof(Dictionary<,>.KeyCollection), false)]
-        [InlineData(typeof(Dictionary<,>.ValueCollection), false)]
-        [InlineData(typeof(SortedDictionary<,>.KeyCollection), false)]
-        [InlineData(typeof(SortedDictionary<,>.ValueCollection), false)]
-        [InlineData(typeof(Dictionary<string, int>), true)]
-        [InlineData(typeof(IEnumerable<string>), true)]
-        [InlineData(typeof(ICollection<string>), true)]
-        [InlineData(typeof(Collection<string>), true)]
-        [InlineData(typeof(IList<string>), true)]
-        [InlineData(typeof(List<string>), true)]
-        [InlineData(typeof(LinkedList<string>), true)]
-        [InlineData(typeof(HashSet<string>), true)]
-        [InlineData(typeof(InheritedGenericCollection), true)]
-        public void CreateValidatesWhetherTypeIsSupportedTest(Type type, bool supported)
-        {
-            var buildChain = new BuildHistory();
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-            var typeResolver = Substitute.For<ITypeResolver>();
-            var configuration = Substitute.For<IBuildConfiguration>();
-
-            configuration.TypeResolver.Returns(typeResolver);
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(configuration);
-
-            var sut = new EnumerableTypeCreator();
-
-            Action action = () => sut.Create(executeStrategy, type);
-
-            if (supported)
-            {
-                action.Should().NotThrow();
-            }
-            else
-            {
-                action.Should().Throw<NotSupportedException>();
-            }
+            actual.Should().BeOfType(expectedType);
+            actual.Should().BeAssignableTo(requestedType);
+            actual.As<IEnumerable>().Should().BeEmpty();
         }
 
         [Fact]
@@ -369,11 +313,8 @@
             var buildChain = new BuildHistory();
 
             var executeStrategy = Substitute.For<IExecuteStrategy>();
-            var typeResolver = Substitute.For<ITypeResolver>();
             var configuration = Substitute.For<IBuildConfiguration>();
 
-            configuration.TypeResolver.Returns(typeResolver);
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
             executeStrategy.BuildChain.Returns(buildChain);
             executeStrategy.Configuration.Returns(configuration);
 
@@ -432,10 +373,7 @@
             var buildChain = new BuildHistory();
             var executeStrategy = Substitute.For<IExecuteStrategy>();
             var configuration = Substitute.For<IBuildConfiguration>();
-            var typeResolver = Substitute.For<ITypeResolver>();
 
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
-            configuration.TypeResolver.Returns(typeResolver);
             executeStrategy.Configuration.Returns(configuration);
             executeStrategy.BuildChain.Returns(buildChain);
             executeStrategy.Create(typeof(Guid)).Returns(Guid.NewGuid());
@@ -483,10 +421,7 @@
             var buildChain = new BuildHistory();
             var executeStrategy = Substitute.For<IExecuteStrategy>();
             var configuration = Substitute.For<IBuildConfiguration>();
-            var typeResolver = Substitute.For<ITypeResolver>();
 
-            typeResolver.GetBuildType(configuration, Arg.Any<Type>()).Returns(x => x.Arg<Type>());
-            configuration.TypeResolver.Returns(typeResolver);
             executeStrategy.Configuration.Returns(configuration);
             executeStrategy.BuildChain.Returns(buildChain);
 
@@ -508,9 +443,21 @@
 
         private class EnumerableTypeCreatorWrapper : EnumerableTypeCreator
         {
+            public object CreateByName(IExecuteStrategy executeStrategy, Type type, string referenceName,
+                params object[] args)
+            {
+                return Create(executeStrategy, type, referenceName, args);
+            }
+
             public void CreateItem(Type type, IExecuteStrategy executeStrategy, object item)
             {
                 CreateChildItem(type, executeStrategy, item);
+            }
+
+            public object CreateValue(IExecuteStrategy executeStrategy, Type type, string referenceName,
+                params object[] args)
+            {
+                return CreateInstance(executeStrategy, type, referenceName, args);
             }
         }
     }

--- a/ModelBuilder/TypeCreators/DefaultTypeCreator.cs
+++ b/ModelBuilder/TypeCreators/DefaultTypeCreator.cs
@@ -24,9 +24,6 @@
         {
             Debug.Assert(type != null, "type != null");
 
-            // TODO: Resolve the type to build
-            // buildLog.MappedType(requestedType, typeMappingRule.TargetType);
-
             if (args == null)
             {
                 return Activator.CreateInstance(type);

--- a/ModelBuilder/TypeCreators/TypeCreatorBase.cs
+++ b/ModelBuilder/TypeCreators/TypeCreatorBase.cs
@@ -230,7 +230,7 @@ namespace ModelBuilder.TypeCreators
 
             var buildType = ResolveBuildType(executeStrategy.Configuration, type);
 
-            if (CanCreate(executeStrategy.Configuration, executeStrategy.BuildChain, type, referenceName) == false)
+            if (CanCreate(executeStrategy.Configuration, executeStrategy.BuildChain, buildType, referenceName) == false)
             {
                 var message = string.Format(
                     CultureInfo.CurrentCulture,


### PR DESCRIPTION
Added strong type handling on ReadOnly types
Added better support for other enumerable types
Fixed bug in TypeCreatorBase which evaluated the wrong type on Create
Added performance fix on DefaultTypeResolver to not search for types when a List<object> or List<T> scenario could be supported