### PR TITLE
Refactored BuildCapability expose create/populate methods

### DIFF
--- a/ModelBuilder.UnitTests/BuildActions/BuildCapabilityTests.cs
+++ b/ModelBuilder.UnitTests/BuildActions/BuildCapabilityTests.cs
@@ -1,28 +1,542 @@
 ﻿namespace ModelBuilder.UnitTests.BuildActions
 {
     using System;
+    using System.Linq;
     using FluentAssertions;
     using ModelBuilder.BuildActions;
+    using ModelBuilder.CreationRules;
+    using ModelBuilder.TypeCreators;
+    using ModelBuilder.UnitTests.Models;
     using ModelBuilder.ValueGenerators;
+    using NSubstitute;
     using Xunit;
 
     public class BuildCapabilityTests
     {
         [Fact]
-        public void ImplementedByTypeReturnsConstructorParameter()
+        public void AutoDetectConstructorReturnsFalseForCreationRule()
         {
-            var type = typeof(EmailValueGenerator);
+            var creationRule = new DummyCreationRule();
 
-            var sut = new BuildCapability(type);
+            var sut = new BuildCapability(creationRule);
 
-            sut.ImplementedByType.Should().Be(type);
+            sut.AutoDetectConstructor.Should().BeFalse();
         }
 
         [Fact]
-        public void ThrowsExceptionWithNullImplementedByType()
+        public void AutoDetectConstructorReturnsFalseForValueGenerator()
+        {
+            var generator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(generator);
+
+            sut.AutoDetectConstructor.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AutoDetectConstructorReturnsTypeCreatorValue(bool autoDetectConstructor)
+        {
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            typeCreator.AutoDetectConstructor.Returns(autoDetectConstructor);
+
+            var sut = new BuildCapability(typeCreator, false, autoDetectConstructor);
+
+            sut.AutoDetectConstructor.Should().Be(autoDetectConstructor);
+        }
+
+        [Fact]
+        public void AutoPopulateReturnsFalseForCreationRule()
+        {
+            var creationRule = new DummyCreationRule();
+
+            var sut = new BuildCapability(creationRule);
+
+            sut.AutoPopulate.Should().BeFalse();
+        }
+
+        [Fact]
+        public void AutoPopulateReturnsFalseForValueGenerator()
+        {
+            var generator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(generator);
+
+            sut.AutoPopulate.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void AutoPopulateReturnsTypeCreatorValue(bool autoPopulate)
+        {
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            typeCreator.AutoPopulate.Returns(autoPopulate);
+
+            var sut = new BuildCapability(typeCreator, false, autoPopulate);
+
+            sut.AutoPopulate.Should().Be(autoPopulate);
+        }
+
+        [Fact]
+        public void CreateParameterReturnsValueFromCreationRule()
+        {
+            var parameterInfo = typeof(Person).GetConstructors()
+                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
+            var value = Guid.NewGuid().ToString();
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var creationRule = Substitute.For<ICreationRule>();
+
+            creationRule.Create(executeStrategy, parameterInfo)
+                .Returns(value);
+
+            var sut = new BuildCapability(creationRule);
+
+            var actual = sut.CreateParameter(executeStrategy, parameterInfo, null);
+
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void CreateParameterReturnsValueFromTypeCreator()
+        {
+            var parameterInfo = typeof(Person).GetConstructors()
+                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
+            var value = Guid.NewGuid().ToString();
+            var args = new object?[]
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            typeCreator.Create(executeStrategy, parameterInfo, args)
+                .Returns(value);
+
+            var sut = new BuildCapability(typeCreator, true, false);
+
+            var actual = sut.CreateParameter(executeStrategy, parameterInfo, args);
+
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void CreateParameterReturnsValueFromValueGenerator()
+        {
+            var parameterInfo = typeof(Person).GetConstructors()
+                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
+            var value = Guid.NewGuid().ToString();
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            valueGenerator.Generate(executeStrategy, parameterInfo)
+                .Returns(value);
+
+            var sut = new BuildCapability(valueGenerator);
+
+            var actual = sut.CreateParameter(executeStrategy, parameterInfo, null);
+
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void CreateParameterThrowsExceptionWithNullExecuteStrategy()
+        {
+            var parameterInfo = typeof(Person).GetConstructors()
+                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
+
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(valueGenerator);
+
+            Action action = () => sut.CreateParameter(null!, parameterInfo, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void CreateParameterThrowsExceptionWithNullParameter()
+        {
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(valueGenerator);
+
+            Action action = () => sut.CreateParameter(executeStrategy, null!, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void CreatePropertyReturnsValueFromCreationRule()
+        {
+            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
+            var value = Guid.NewGuid().ToString();
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var creationRule = Substitute.For<ICreationRule>();
+
+            creationRule.Create(executeStrategy, propertyInfo).Returns(value);
+
+            var sut = new BuildCapability(creationRule);
+
+            var actual = sut.CreateProperty(executeStrategy, propertyInfo, null);
+
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void CreatePropertyReturnsValueFromTypeCreator()
+        {
+            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
+            var value = Guid.NewGuid().ToString();
+            var args = new object?[]
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            typeCreator.Create(executeStrategy, propertyInfo, args).Returns(value);
+
+            var sut = new BuildCapability(typeCreator, true, false);
+
+            var actual = sut.CreateProperty(executeStrategy, propertyInfo, args);
+
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void CreatePropertyReturnsValueFromValueGenerator()
+        {
+            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
+            var value = Guid.NewGuid().ToString();
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            valueGenerator.Generate(executeStrategy, propertyInfo).Returns(value);
+
+            var sut = new BuildCapability(valueGenerator);
+
+            var actual = sut.CreateProperty(executeStrategy, propertyInfo, null);
+
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void CreatePropertyThrowsExceptionWithNullExecuteStrategy()
+        {
+            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
+
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(valueGenerator);
+
+            Action action = () => sut.CreateProperty(null!, propertyInfo, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void CreatePropertyThrowsExceptionWithNullProperty()
+        {
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(valueGenerator);
+
+            Action action = () => sut.CreateProperty(executeStrategy, null!, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void CreateTypeReturnsValueFromCreationRule()
+        {
+            var type = typeof(string);
+            var value = Guid.NewGuid().ToString();
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var creationRule = Substitute.For<ICreationRule>();
+
+            creationRule.Create(executeStrategy, type).Returns(value);
+
+            var sut = new BuildCapability(creationRule);
+
+            var actual = sut.CreateType(executeStrategy, type, null);
+
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void CreateTypeReturnsValueFromTypeCreator()
+        {
+            var type = typeof(string);
+            var value = Guid.NewGuid().ToString();
+            var args = new object?[]
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            typeCreator.Create(executeStrategy, type, args).Returns(value);
+
+            var sut = new BuildCapability(typeCreator, true, false);
+
+            var actual = sut.CreateType(executeStrategy, type, args);
+
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void CreateTypeReturnsValueFromValueGenerator()
+        {
+            var type = typeof(string);
+            var value = Guid.NewGuid().ToString();
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            valueGenerator.Generate(executeStrategy, type).Returns(value);
+
+            var sut = new BuildCapability(valueGenerator);
+
+            var actual = sut.CreateType(executeStrategy, type, null);
+
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void CreateTypeThrowsExceptionWithNullExecuteStrategy()
+        {
+            var targetType = typeof(string);
+
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(valueGenerator);
+
+            Action action = () => sut.CreateType(null!, targetType, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void CreateTypeThrowsExceptionWithNullType()
+        {
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(valueGenerator);
+
+            Action action = () => sut.CreateType(executeStrategy, null!, null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ImplementedByTypeReturnsCreationRuleType()
+        {
+            var creationRule = new DummyCreationRule();
+
+            var sut = new BuildCapability(creationRule);
+
+            sut.ImplementedByType.Should().Be<DummyCreationRule>();
+        }
+
+        [Fact]
+        public void ImplementedByTypeReturnsGeneratorType()
+        {
+            var generator = new EmailValueGenerator();
+
+            var sut = new BuildCapability(generator);
+
+            sut.ImplementedByType.Should().Be<EmailValueGenerator>();
+        }
+
+        [Fact]
+        public void ImplementedByTypeReturnsTypeCreatorType()
+        {
+            var creator = new DefaultTypeCreator();
+
+            var sut = new BuildCapability(creator, false, false);
+
+            sut.ImplementedByType.Should().Be<DefaultTypeCreator>();
+        }
+
+        [Fact]
+        public void PopulateThrowsExceptionWithNullExecuteStrategy()
+        {
+            var value = new Person();
+
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            var sut = new BuildCapability(typeCreator, true, true);
+
+            Action action = () => sut.Populate(null!, value);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void PopulateThrowsExceptionWithNullProperty()
+        {
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            var sut = new BuildCapability(typeCreator, true, true);
+
+            Action action = () => sut.Populate(executeStrategy, null!);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void PopulateWithCreationRuleThrowsException()
+        {
+            var value = new Person();
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var creationRule = Substitute.For<ICreationRule>();
+
+            var sut = new BuildCapability(creationRule);
+
+            Action action = () => sut.Populate(executeStrategy, value);
+
+            action.Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void PopulateWithTypeCreatorReturnsValue()
+        {
+            var expected = new Person();
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            typeCreator.Populate(executeStrategy, expected).Returns(expected);
+
+            var sut = new BuildCapability(typeCreator, false, true);
+
+            var actual = sut.Populate(executeStrategy, expected);
+
+            actual.Should().Be(expected);
+        }
+
+        [Fact]
+        public void PopulateWithValueGeneratorThrowsException()
+        {
+            var value = new Person();
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            var valueGenerator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(valueGenerator);
+
+            Action action = () => sut.Populate(executeStrategy, value);
+
+            action.Should().Throw<NotSupportedException>();
+        }
+
+        [Fact]
+        public void SupportsCreateReturnsTrueForCreationRule()
+        {
+            var creationRule = new DummyCreationRule();
+
+            var sut = new BuildCapability(creationRule);
+
+            sut.SupportsCreate.Should().BeTrue();
+        }
+
+        [Fact]
+        public void SupportsCreateReturnsTrueForValueGenerator()
+        {
+            var generator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(generator);
+
+            sut.SupportsCreate.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SupportsCreateReturnsTypeCreatorValue(bool supportsCreate)
+        {
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            var sut = new BuildCapability(typeCreator, supportsCreate, false);
+
+            sut.SupportsCreate.Should().Be(supportsCreate);
+        }
+
+        [Fact]
+        public void SupportsPopulateReturnsFalseForCreationRule()
+        {
+            var creationRule = new DummyCreationRule();
+
+            var sut = new BuildCapability(creationRule);
+
+            sut.SupportsPopulate.Should().BeFalse();
+        }
+
+        [Fact]
+        public void SupportsPopulateReturnsFalseForValueGenerator()
+        {
+            var generator = Substitute.For<IValueGenerator>();
+
+            var sut = new BuildCapability(generator);
+
+            sut.SupportsPopulate.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void SupportsPopulateReturnsTypeCreatorValue(bool supportsPopulate)
+        {
+            var typeCreator = Substitute.For<ITypeCreator>();
+
+            var sut = new BuildCapability(typeCreator, false, supportsPopulate);
+
+            sut.SupportsPopulate.Should().Be(supportsPopulate);
+        }
+
+        [Fact]
+        public void ThrowsExceptionWithNullCreationRule()
         {
             // ReSharper disable once ObjectCreationAsStatement
-            Action action = () => new BuildCapability(null!);
+            Action action = () => new BuildCapability((ICreationRule) null!);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ThrowsExceptionWithNullTypeCreator()
+        {
+            // ReSharper disable once ObjectCreationAsStatement
+            Action action = () => new BuildCapability(null!, false, false);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void ThrowsExceptionWithNullValueGenerator()
+        {
+            // ReSharper disable once ObjectCreationAsStatement
+            Action action = () => new BuildCapability((IValueGenerator) null!);
 
             action.Should().Throw<ArgumentNullException>();
         }

--- a/ModelBuilder.UnitTests/BuildActions/CircularReferenceBuildActionTests.cs
+++ b/ModelBuilder.UnitTests/BuildActions/CircularReferenceBuildActionTests.cs
@@ -5,6 +5,7 @@
     using System.Reflection;
     using FluentAssertions;
     using ModelBuilder.BuildActions;
+    using ModelBuilder.CreationRules;
     using ModelBuilder.UnitTests.Models;
     using NSubstitute;
     using Xunit;
@@ -213,6 +214,30 @@
         }
 
         [Fact]
+        public void GetBuildCapabilityForParameterReturnsCapabilityWhenBuildChainContainsMatchingType()
+        {
+            var parameterInfo = typeof(Person).GetConstructors()
+                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
+            var buildConfiguration = new BuildConfiguration();
+            var buildChain = new BuildHistory();
+
+            buildChain.Push(Guid.NewGuid());
+            buildChain.Push(Guid.NewGuid().ToString());
+            buildChain.Push(DateTimeOffset.UtcNow);
+
+            var sut = new CircularReferenceBuildAction();
+
+            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, parameterInfo)!;
+
+            actual.Should().NotBeNull();
+            actual.SupportsCreate.Should().BeTrue();
+            actual.SupportsPopulate.Should().BeFalse();
+            actual.AutoDetectConstructor.Should().BeFalse();
+            actual.AutoPopulate.Should().BeFalse();
+            actual.ImplementedByType.Should().BeAssignableTo<IBuildCapability>();
+        }
+
+        [Fact]
         public void GetBuildCapabilityForParameterReturnsNullWhenBuildChainDoesNotContainMatchingType()
         {
             var buildConfiguration = new BuildConfiguration();
@@ -245,30 +270,6 @@
         }
 
         [Fact]
-        public void GetBuildCapabilityForParameterReturnsCapabilityWhenBuildChainContainsMatchingType()
-        {
-            var parameterInfo = typeof(Person).GetConstructors()
-                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-            var buildConfiguration = new BuildConfiguration();
-            var buildChain = new BuildHistory();
-
-            buildChain.Push(Guid.NewGuid());
-            buildChain.Push(Guid.NewGuid().ToString());
-            buildChain.Push(DateTimeOffset.UtcNow);
-
-            var sut = new CircularReferenceBuildAction();
-
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, parameterInfo)!;
-
-            actual.Should().NotBeNull();
-            actual.SupportsCreate.Should().BeTrue();
-            actual.SupportsPopulate.Should().BeFalse();
-            actual.AutoDetectConstructor.Should().BeFalse();
-            actual.AutoPopulate.Should().BeFalse();
-            actual.ImplementedByType.Should().Be<CircularReferenceBuildAction>();
-        }
-
-        [Fact]
         public void GetBuildCapabilityForParameterThrowsExceptionWithNullBuildChain()
         {
             var parameterInfo = typeof(Person).GetConstructors()
@@ -293,6 +294,29 @@
             Action action = () => sut.GetBuildCapability(buildConfiguration, buildChain, (ParameterInfo) null!);
 
             action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetBuildCapabilityForPropertyReturnsCapabilityWhenBuildChainContainsMatchingType()
+        {
+            var buildConfiguration = new BuildConfiguration();
+            var buildChain = new BuildHistory();
+            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
+
+            buildChain.Push(Guid.NewGuid());
+            buildChain.Push(Guid.NewGuid().ToString());
+            buildChain.Push(DateTimeOffset.UtcNow);
+
+            var sut = new CircularReferenceBuildAction();
+
+            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, propertyInfo);
+
+            actual.Should().NotBeNull();
+            actual!.SupportsCreate.Should().BeTrue();
+            actual.SupportsPopulate.Should().BeFalse();
+            actual.AutoDetectConstructor.Should().BeFalse();
+            actual.AutoPopulate.Should().BeFalse();
+            actual.ImplementedByType.Should().BeAssignableTo<IBuildCapability>();
         }
 
         [Fact]
@@ -326,29 +350,6 @@
         }
 
         [Fact]
-        public void GetBuildCapabilityForPropertyReturnsCapabilityWhenBuildChainContainsMatchingType()
-        {
-            var buildConfiguration = new BuildConfiguration();
-            var buildChain = new BuildHistory();
-            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
-
-            buildChain.Push(Guid.NewGuid());
-            buildChain.Push(Guid.NewGuid().ToString());
-            buildChain.Push(DateTimeOffset.UtcNow);
-
-            var sut = new CircularReferenceBuildAction();
-
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, propertyInfo);
-
-            actual.Should().NotBeNull();
-            actual!.SupportsCreate.Should().BeTrue();
-            actual.SupportsPopulate.Should().BeFalse();
-            actual.AutoDetectConstructor.Should().BeFalse();
-            actual.AutoPopulate.Should().BeFalse();
-            actual.ImplementedByType.Should().Be<CircularReferenceBuildAction>();
-        }
-
-        [Fact]
         public void GetBuildCapabilityForPropertyThrowsExceptionWithNullBuildChain()
         {
             var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
@@ -372,6 +373,29 @@
             Action action = () => sut.GetBuildCapability(buildConfiguration, buildChain, (PropertyInfo) null!);
 
             action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetBuildCapabilityForTypeReturnsCapabilityWhenBuildChainContainsMatchingType()
+        {
+            var buildConfiguration = new BuildConfiguration();
+            var buildChain = new BuildHistory();
+            var type = typeof(string);
+
+            buildChain.Push(Guid.NewGuid());
+            buildChain.Push(Guid.NewGuid().ToString());
+            buildChain.Push(DateTimeOffset.UtcNow);
+
+            var sut = new CircularReferenceBuildAction();
+
+            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, type);
+
+            actual.Should().NotBeNull();
+            actual!.SupportsCreate.Should().BeTrue();
+            actual.SupportsPopulate.Should().BeFalse();
+            actual.AutoDetectConstructor.Should().BeFalse();
+            actual.AutoPopulate.Should().BeFalse();
+            actual.ImplementedByType.Should().BeAssignableTo<IBuildCapability>();
         }
 
         [Fact]
@@ -405,29 +429,6 @@
         }
 
         [Fact]
-        public void GetBuildCapabilityForTypeReturnsCapabilityWhenBuildChainContainsMatchingType()
-        {
-            var buildConfiguration = new BuildConfiguration();
-            var buildChain = new BuildHistory();
-            var type = typeof(string);
-
-            buildChain.Push(Guid.NewGuid());
-            buildChain.Push(Guid.NewGuid().ToString());
-            buildChain.Push(DateTimeOffset.UtcNow);
-
-            var sut = new CircularReferenceBuildAction();
-
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, type);
-
-            actual.Should().NotBeNull();
-            actual!.SupportsCreate.Should().BeTrue();
-            actual.SupportsPopulate.Should().BeFalse();
-            actual.AutoDetectConstructor.Should().BeFalse();
-            actual.AutoPopulate.Should().BeFalse();
-            actual.ImplementedByType.Should().Be<CircularReferenceBuildAction>();
-        }
-
-        [Fact]
         public void GetBuildCapabilityForTypeThrowsExceptionWithNullBuildChain()
         {
             var type = typeof(string);
@@ -451,6 +452,29 @@
             Action action = () => sut.GetBuildCapability(buildConfiguration, buildChain, (Type) null!);
 
             action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetBuildCapabilityReturnsCapabilityWithoutPopulateSupport()
+        {
+            var value = new Person();
+            var buildConfiguration = new BuildConfiguration();
+            var buildChain = new BuildHistory();
+            var type = typeof(string);
+
+            buildChain.Push(Guid.NewGuid());
+            buildChain.Push(Guid.NewGuid().ToString());
+            buildChain.Push(DateTimeOffset.UtcNow);
+
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+
+            var sut = new CircularReferenceBuildAction();
+
+            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, type)!;
+
+            Action action = () => actual.Populate(executeStrategy, value);
+
+            action.Should().Throw<NotSupportedException>();
         }
 
         [Fact]

--- a/ModelBuilder.UnitTests/BuildProcessorTests.cs
+++ b/ModelBuilder.UnitTests/BuildProcessorTests.cs
@@ -6,444 +6,12 @@
     using System.Reflection;
     using FluentAssertions;
     using ModelBuilder.BuildActions;
-    using ModelBuilder.TypeCreators;
     using ModelBuilder.UnitTests.Models;
     using NSubstitute;
     using Xunit;
 
     public class BuildProcessorTests
     {
-        [Fact]
-        public void BuildForParameterReturnsActionValue()
-        {
-            var parameterInfo = typeof(Person).GetConstructors()
-                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-            var arguments = new object[] {Guid.NewGuid().ToString()};
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-
-            var action = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            action.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(match);
-            action.Build(executeStrategy, parameterInfo, arguments).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                action
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Build(executeStrategy, parameterInfo, arguments);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void BuildForParameterReturnsValueFromActionWithHighestPriority()
-        {
-            var parameterInfo = typeof(Person).GetConstructors()
-                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-            var arguments = new object[] {Guid.NewGuid().ToString()};
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MinValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(match);
-            secondAction.Priority.Returns(int.MaxValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(match);
-            secondAction.Build(executeStrategy, parameterInfo, arguments).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Build(executeStrategy, parameterInfo, arguments);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void BuildForParameterReturnsValueFromMatchingAction()
-        {
-            var parameterInfo = typeof(Person).GetConstructors()
-                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-            var arguments = new object[] {Guid.NewGuid().ToString()};
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MaxValue);
-            secondAction.Priority.Returns(int.MinValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(match);
-            secondAction.Build(executeStrategy, parameterInfo, arguments).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Build(executeStrategy, parameterInfo, arguments);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void BuildForParameterThrowsExceptionWhenNoBuildActionFound()
-        {
-            var actions = Array.Empty<IBuildAction>();
-            var parameterInfo = typeof(Person).GetConstructors()
-                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Build(executeStrategy, parameterInfo);
-
-            action.Should().Throw<NotSupportedException>();
-        }
-
-        [Fact]
-        public void BuildForParameterThrowsExceptionWithNullExecuteStrategy()
-        {
-            var actions = Array.Empty<IBuildAction>();
-            var parameterInfo = typeof(Person).GetConstructors()
-                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Build(null!, parameterInfo);
-
-            action.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void BuildForParameterThrowsExceptionWithNullParameter()
-        {
-            var actions = Array.Empty<IBuildAction>();
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Build(executeStrategy, (ParameterInfo) null!);
-
-            action.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void BuildForPropertyReturnsActionValue()
-        {
-            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
-            var arguments = new object[] {Guid.NewGuid().ToString()};
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-
-            var action = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            action.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(match);
-            action.Build(executeStrategy, propertyInfo, arguments).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                action
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Build(executeStrategy, propertyInfo, arguments);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void BuildForPropertyReturnsValueFromActionWithHighestPriority()
-        {
-            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
-            var arguments = new object[] {Guid.NewGuid().ToString()};
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MinValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(match);
-            secondAction.Priority.Returns(int.MaxValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(match);
-            secondAction.Build(executeStrategy, propertyInfo, arguments).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Build(executeStrategy, propertyInfo, arguments);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void BuildForPropertyReturnsValueFromMatchingAction()
-        {
-            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
-            var arguments = new object[] {Guid.NewGuid().ToString()};
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MaxValue);
-            secondAction.Priority.Returns(int.MinValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(match);
-            secondAction.Build(executeStrategy, propertyInfo, arguments).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Build(executeStrategy, propertyInfo, arguments);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void BuildForPropertyThrowsExceptionWhenNoBuildActionFound()
-        {
-            var context = new Person();
-            var actions = Array.Empty<IBuildAction>();
-            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
-            var buildChain = new BuildHistory();
-
-            buildChain.Push(context);
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Build(executeStrategy, propertyInfo);
-
-            action.Should().Throw<NotSupportedException>();
-        }
-
-        [Fact]
-        public void BuildForPropertyThrowsExceptionWithNullExecuteStrategy()
-        {
-            var actions = Array.Empty<IBuildAction>();
-            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Build(null!, propertyInfo);
-
-            action.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void BuildForPropertyThrowsExceptionWithNullProperty()
-        {
-            var actions = Array.Empty<IBuildAction>();
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Build(executeStrategy, (PropertyInfo) null!);
-
-            action.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void BuildForTypeReturnsActionValue()
-        {
-            var type = typeof(Person);
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-
-            var action = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            action.GetBuildCapability(buildConfiguration, buildChain, type).Returns(match);
-            action.Build(executeStrategy, type).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                action
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Build(executeStrategy, type);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void BuildForTypeReturnsValueFromActionWithHighestPriority()
-        {
-            var type = typeof(Person);
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MinValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(match);
-            secondAction.Priority.Returns(int.MaxValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(match);
-            secondAction.Build(executeStrategy, type).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Build(executeStrategy, type);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void BuildForTypeReturnsValueFromMatchingAction()
-        {
-            var type = typeof(Person);
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MaxValue);
-            secondAction.Priority.Returns(int.MinValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(match);
-            secondAction.Build(executeStrategy, type).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Build(executeStrategy, type);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void BuildForTypeThrowsExceptionWhenNoBuildActionFound()
-        {
-            var actions = Array.Empty<IBuildAction>();
-            var type = typeof(Person);
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Build(executeStrategy, type);
-
-            action.Should().Throw<NotSupportedException>();
-        }
-
-        [Fact]
-        public void BuildForTypeThrowsExceptionWithNullExecuteStrategy()
-        {
-            var actions = Array.Empty<IBuildAction>();
-            var type = typeof(Person);
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Build(null!, type);
-
-            action.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void BuildForTypeThrowsExceptionWithNullType()
-        {
-            var actions = Array.Empty<IBuildAction>();
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Build(executeStrategy, (Type) null!);
-
-            action.Should().Throw<ArgumentNullException>();
-        }
-
         [Fact]
         public void CanCreateInstance()
         {
@@ -462,94 +30,72 @@
         [InlineData(BuildRequirement.Populate, true, false, false)]
         [InlineData(BuildRequirement.Populate, false, true, true)]
         [InlineData(BuildRequirement.Populate, false, false, false)]
-        public void GetBuildCapabilityForParameterReturnsBuildPlan(BuildRequirement requirement, bool canCreate,
-            bool canPopulate, bool planExists)
+        public void GetBuildCapabilityForParameterReturnsBuildCapabilityWhenSupported(BuildRequirement requirement,
+            bool canCreate,
+            bool canPopulate, bool capabilityExists)
         {
             var parameterInfo = typeof(Person).GetConstructors()
                 .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-            var capability = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = canCreate, SupportsPopulate = canPopulate};
 
-            var action = Substitute.For<IBuildAction>();
+            var capability = Substitute.For<IBuildCapability>();
+
+            var buildAction = Substitute.For<IBuildAction>();
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
             var buildChain = Substitute.For<IBuildChain>();
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
 
-            action.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(capability);
+            capability.SupportsCreate.Returns(canCreate);
+            capability.SupportsPopulate.Returns(canPopulate);
+            executeStrategy.Configuration.Returns(buildConfiguration);
+            executeStrategy.BuildChain.Returns(buildChain);
+
+            buildAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(capability);
 
             var actions = new List<IBuildAction>
             {
-                action
+                buildAction
             };
 
             var sut = new BuildProcessor(actions);
 
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, requirement, parameterInfo);
-
-            if (planExists)
+            if (capabilityExists)
             {
+                var actual = sut.GetBuildCapability(executeStrategy, requirement, parameterInfo);
+
                 actual.Should().Be(capability);
             }
             else
             {
-                actual.Should().BeNull();
+                Action action = () => sut.GetBuildCapability(executeStrategy, requirement, parameterInfo);
+
+                action.Should().Throw<BuildException>();
             }
         }
 
         [Fact]
-        public void GetBuildCapabilityForParameterReturnsPlanFromActionWithHighestPriority()
+        public void GetBuildCapabilityForParameterReturnsCapabilityFromAction()
         {
             var parameterInfo = typeof(Person).GetConstructors()
                 .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-            var firstMatch = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-            var secondMatch = new BuildCapability(typeof(DefaultTypeCreator))
-                {SupportsCreate = true, SupportsPopulate = true, AutoPopulate = true, AutoDetectConstructor = true};
 
+            var firstCapability = Substitute.For<IBuildCapability>();
+            var secondCapability = Substitute.For<IBuildCapability>();
             var firstAction = Substitute.For<IBuildAction>();
             var secondAction = Substitute.For<IBuildAction>();
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
             var buildChain = Substitute.For<IBuildChain>();
             var executeStrategy = Substitute.For<IExecuteStrategy>();
 
-            executeStrategy.BuildChain.Returns(buildChain);
             executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MinValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(firstMatch);
-            secondAction.Priority.Returns(int.MaxValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(secondMatch);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, BuildRequirement.Create, parameterInfo);
-
-            actual.Should().BeEquivalentTo(secondMatch);
-        }
-
-        [Fact]
-        public void GetBuildCapabilityForParameterReturnsValueFromMatchingAction()
-        {
-            var parameterInfo = typeof(Person).GetConstructors()
-                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-            var firstMatch = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = false};
-            var secondMatch = new BuildCapability(typeof(DefaultTypeCreator))
-                {SupportsCreate = true, SupportsPopulate = true, AutoPopulate = true, AutoDetectConstructor = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
             executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
+            secondCapability.SupportsCreate.Returns(true);
+            secondCapability.SupportsPopulate.Returns(true);
+            secondCapability.AutoPopulate.Returns(true);
+            secondCapability.AutoDetectConstructor.Returns(true);
             firstAction.Priority.Returns(int.MaxValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(firstMatch);
+            firstAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(firstCapability);
             secondAction.Priority.Returns(int.MinValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(secondMatch);
+            secondAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(secondCapability);
 
             var actions = new List<IBuildAction>
             {
@@ -559,40 +105,61 @@
 
             var sut = new BuildProcessor(actions);
 
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, BuildRequirement.Create, parameterInfo);
+            var actual = sut.GetBuildCapability(executeStrategy, BuildRequirement.Create, parameterInfo);
 
-            actual.Should().BeEquivalentTo(secondMatch);
+            actual.Should().BeEquivalentTo(secondCapability);
         }
 
         [Fact]
-        public void GetBuildCapabilityForParameterThrowsExceptionWithNullBuildChain()
+        public void GetBuildCapabilityForParameterReturnsCapabilityFromActionWithHighestPriority()
+        {
+            var parameterInfo = typeof(Person).GetConstructors()
+                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
+
+            var firstCapability = Substitute.For<IBuildCapability>();
+            var secondCapability = Substitute.For<IBuildCapability>();
+            var firstAction = Substitute.For<IBuildAction>();
+            var secondAction = Substitute.For<IBuildAction>();
+            var buildConfiguration = Substitute.For<IBuildConfiguration>();
+            var buildChain = Substitute.For<IBuildChain>();
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+
+            firstCapability.SupportsCreate.Returns(true);
+            secondCapability.SupportsCreate.Returns(true);
+            secondCapability.SupportsPopulate.Returns(true);
+            secondCapability.AutoPopulate.Returns(true);
+            secondCapability.AutoDetectConstructor.Returns(true);
+            executeStrategy.Configuration.Returns(buildConfiguration);
+            executeStrategy.BuildChain.Returns(buildChain);
+            firstAction.Priority.Returns(int.MinValue);
+            firstAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(firstCapability);
+            secondAction.Priority.Returns(int.MaxValue);
+            secondAction.GetBuildCapability(buildConfiguration, buildChain, parameterInfo).Returns(secondCapability);
+
+            var actions = new List<IBuildAction>
+            {
+                firstAction,
+                secondAction
+            };
+
+            var sut = new BuildProcessor(actions);
+
+            var actual = sut.GetBuildCapability(executeStrategy, BuildRequirement.Create, parameterInfo);
+
+            actual.Should().BeEquivalentTo(secondCapability);
+        }
+
+        [Fact]
+        public void GetBuildCapabilityForParameterThrowsExceptionWithNullExecuteStrategy()
         {
             var actions = Array.Empty<IBuildAction>();
             var parameterInfo = typeof(Person).GetConstructors()
                 .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
 
             var sut = new BuildProcessor(actions);
 
             Action action = () =>
-                sut.GetBuildCapability(buildConfiguration, null!, BuildRequirement.Create, parameterInfo);
-
-            action.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void GetBuildCapabilityForParameterThrowsExceptionWithNullBuildConfiguration()
-        {
-            var actions = Array.Empty<IBuildAction>();
-            var parameterInfo = typeof(Person).GetConstructors()
-                .First(x => x.GetParameters().FirstOrDefault()?.Name == "firstName").GetParameters().First();
-
-            var buildChain = Substitute.For<IBuildChain>();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.GetBuildCapability(null!, buildChain, BuildRequirement.Create, parameterInfo);
+                sut.GetBuildCapability(null!, BuildRequirement.Create, parameterInfo);
 
             action.Should().Throw<ArgumentNullException>();
         }
@@ -604,11 +171,14 @@
 
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
             var buildChain = Substitute.For<IBuildChain>();
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            executeStrategy.Configuration.Returns(buildConfiguration);
+            executeStrategy.BuildChain.Returns(buildChain);
 
             var sut = new BuildProcessor(actions);
 
             Action action = () =>
-                sut.GetBuildCapability(buildConfiguration, buildChain, BuildRequirement.Create, (ParameterInfo) null!);
+                sut.GetBuildCapability(executeStrategy, BuildRequirement.Create, (ParameterInfo) null!);
 
             action.Should().Throw<ArgumentNullException>();
         }
@@ -622,91 +192,68 @@
         [InlineData(BuildRequirement.Populate, true, false, false)]
         [InlineData(BuildRequirement.Populate, false, true, true)]
         [InlineData(BuildRequirement.Populate, false, false, false)]
-        public void GetBuildCapabilityForPropertyReturnsBuildPlan(BuildRequirement requirement, bool canCreate,
-            bool canPopulate, bool planExists)
+        public void GetBuildCapabilityForPropertyReturnsBuildCapabilityWhenSupported(BuildRequirement requirement,
+            bool canCreate,
+            bool canPopulate, bool capabilityExists)
         {
             var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
-            var capability = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = canCreate, SupportsPopulate = canPopulate};
+            var capability = Substitute.For<IBuildCapability>();
+            capability.SupportsCreate.Returns(canCreate);
+            capability.SupportsPopulate.Returns(canPopulate);
 
-            var action = Substitute.For<IBuildAction>();
+            var buildAction = Substitute.For<IBuildAction>();
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
             var buildChain = Substitute.For<IBuildChain>();
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            executeStrategy.Configuration.Returns(buildConfiguration);
+            executeStrategy.BuildChain.Returns(buildChain);
 
-            action.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(capability);
+            buildAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(capability);
 
             var actions = new List<IBuildAction>
             {
-                action
+                buildAction
             };
 
             var sut = new BuildProcessor(actions);
 
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, requirement, propertyInfo);
-
-            if (planExists)
+            if (capabilityExists)
             {
+                var actual = sut.GetBuildCapability(executeStrategy, requirement, propertyInfo);
+
                 actual.Should().Be(capability);
             }
             else
             {
-                actual.Should().BeNull();
+                Action action = () => sut.GetBuildCapability(executeStrategy, requirement, propertyInfo);
+
+                action.Should().Throw<BuildException>();
             }
         }
 
         [Fact]
-        public void GetBuildCapabilityForPropertyReturnsPlanFromActionWithHighestPriority()
+        public void GetBuildCapabilityForPropertyReturnsCapabilityFromAction()
         {
             var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
-            var firstMatch = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-            var secondMatch = new BuildCapability(typeof(DefaultTypeCreator))
-                {SupportsCreate = true, SupportsPopulate = true, AutoPopulate = true, AutoDetectConstructor = true};
 
+            var firstCapability = Substitute.For<IBuildCapability>();
+            var secondCapability = Substitute.For<IBuildCapability>();
             var firstAction = Substitute.For<IBuildAction>();
             var secondAction = Substitute.For<IBuildAction>();
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
             var buildChain = Substitute.For<IBuildChain>();
             var executeStrategy = Substitute.For<IExecuteStrategy>();
 
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MinValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(firstMatch);
-            secondAction.Priority.Returns(int.MaxValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(secondMatch);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, BuildRequirement.Create, propertyInfo);
-
-            actual.Should().BeEquivalentTo(secondMatch);
-        }
-
-        [Fact]
-        public void GetBuildCapabilityForPropertyReturnsValueFromMatchingAction()
-        {
-            var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
-            var firstMatch = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = false};
-            var secondMatch = new BuildCapability(typeof(DefaultTypeCreator))
-                {SupportsCreate = true, SupportsPopulate = true, AutoPopulate = true, AutoDetectConstructor = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
+            secondCapability.SupportsCreate.Returns(true);
+            secondCapability.SupportsPopulate.Returns(true);
+            secondCapability.AutoPopulate.Returns(true);
+            secondCapability.AutoDetectConstructor.Returns(true);
             executeStrategy.BuildChain.Returns(buildChain);
             executeStrategy.Configuration.Returns(buildConfiguration);
             firstAction.Priority.Returns(int.MaxValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(firstMatch);
+            firstAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(firstCapability);
             secondAction.Priority.Returns(int.MinValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(secondMatch);
+            secondAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(secondCapability);
 
             var actions = new List<IBuildAction>
             {
@@ -716,38 +263,58 @@
 
             var sut = new BuildProcessor(actions);
 
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, BuildRequirement.Create, propertyInfo);
+            var actual = sut.GetBuildCapability(executeStrategy, BuildRequirement.Create, propertyInfo);
 
-            actual.Should().BeEquivalentTo(secondMatch);
+            actual.Should().BeEquivalentTo(secondCapability);
         }
 
         [Fact]
-        public void GetBuildCapabilityForPropertyThrowsExceptionWithNullBuildChain()
+        public void GetBuildCapabilityForPropertyReturnsCapabilityFromActionWithHighestPriority()
         {
-            var actions = Array.Empty<IBuildAction>();
             var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
+            var firstCapability = Substitute.For<IBuildCapability>();
+            var secondCapability = Substitute.For<IBuildCapability>();
 
+            var firstAction = Substitute.For<IBuildAction>();
+            var secondAction = Substitute.For<IBuildAction>();
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
+            var buildChain = Substitute.For<IBuildChain>();
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+
+            firstCapability.SupportsCreate.Returns(true);
+            secondCapability.SupportsCreate.Returns(true);
+            secondCapability.SupportsPopulate.Returns(true);
+            secondCapability.AutoPopulate.Returns(true);
+            secondCapability.AutoDetectConstructor.Returns(true);
+            executeStrategy.BuildChain.Returns(buildChain);
+            executeStrategy.Configuration.Returns(buildConfiguration);
+            firstAction.Priority.Returns(int.MinValue);
+            firstAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(firstCapability);
+            secondAction.Priority.Returns(int.MaxValue);
+            secondAction.GetBuildCapability(buildConfiguration, buildChain, propertyInfo).Returns(secondCapability);
+
+            var actions = new List<IBuildAction>
+            {
+                firstAction,
+                secondAction
+            };
 
             var sut = new BuildProcessor(actions);
 
-            Action action = () =>
-                sut.GetBuildCapability(buildConfiguration, null!, BuildRequirement.Create, propertyInfo);
+            var actual = sut.GetBuildCapability(executeStrategy, BuildRequirement.Create, propertyInfo);
 
-            action.Should().Throw<ArgumentNullException>();
+            actual.Should().BeEquivalentTo(secondCapability);
         }
 
         [Fact]
-        public void GetBuildCapabilityForPropertyThrowsExceptionWithNullBuildConfiguration()
+        public void GetBuildCapabilityForPropertyThrowsExceptionWithNullExecuteStrategy()
         {
             var actions = Array.Empty<IBuildAction>();
             var propertyInfo = typeof(Person).GetProperty(nameof(Person.FirstName))!;
 
-            var buildChain = Substitute.For<IBuildChain>();
-
             var sut = new BuildProcessor(actions);
 
-            Action action = () => sut.GetBuildCapability(null!, buildChain, BuildRequirement.Create, propertyInfo);
+            Action action = () => sut.GetBuildCapability(null!, BuildRequirement.Create, propertyInfo);
 
             action.Should().Throw<ArgumentNullException>();
         }
@@ -759,11 +326,14 @@
 
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
             var buildChain = Substitute.For<IBuildChain>();
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            executeStrategy.Configuration.Returns(buildConfiguration);
+            executeStrategy.BuildChain.Returns(buildChain);
 
             var sut = new BuildProcessor(actions);
 
             Action action = () =>
-                sut.GetBuildCapability(buildConfiguration, buildChain, BuildRequirement.Create, (PropertyInfo) null!);
+                sut.GetBuildCapability(executeStrategy, BuildRequirement.Create, (PropertyInfo) null!);
 
             action.Should().Throw<ArgumentNullException>();
         }
@@ -777,44 +347,51 @@
         [InlineData(BuildRequirement.Populate, true, false, false)]
         [InlineData(BuildRequirement.Populate, false, true, true)]
         [InlineData(BuildRequirement.Populate, false, false, false)]
-        public void GetBuildCapabilityForTypeReturnsBuildPlan(BuildRequirement requirement, bool canCreate,
+        public void GetBuildCapabilityForTypeReturnsBuildCapability(BuildRequirement requirement, bool canCreate,
             bool canPopulate, bool planExists)
         {
             var type = typeof(Person);
-            var capability = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = canCreate, SupportsPopulate = canPopulate};
 
-            var action = Substitute.For<IBuildAction>();
+            var capability = Substitute.For<IBuildCapability>();
+            var buildAction = Substitute.For<IBuildAction>();
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
             var buildChain = Substitute.For<IBuildChain>();
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
 
-            action.GetBuildCapability(buildConfiguration, buildChain, type).Returns(capability);
+            capability.SupportsCreate.Returns(canCreate);
+            capability.SupportsPopulate.Returns(canPopulate);
+            executeStrategy.Configuration.Returns(buildConfiguration);
+            executeStrategy.BuildChain.Returns(buildChain);
+
+            buildAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(capability);
 
             var actions = new List<IBuildAction>
             {
-                action
+                buildAction
             };
 
             var sut = new BuildProcessor(actions);
 
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, requirement, type);
-
             if (planExists)
             {
+                var actual = sut.GetBuildCapability(executeStrategy, requirement, type);
+
                 actual.Should().Be(capability);
             }
             else
             {
-                actual.Should().BeNull();
+                Action action = () => sut.GetBuildCapability(executeStrategy, requirement, type);
+
+                action.Should().Throw<BuildException>();
             }
         }
 
         [Fact]
-        public void GetBuildCapabilityForTypeReturnsPlanFromActionWithHighestPriority()
+        public void GetBuildCapabilityForTypeReturnsCapabilityFromAction()
         {
             var type = typeof(Person);
-            var firstMatch = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = true};
-            var secondMatch = new BuildCapability(typeof(DefaultTypeCreator))
-                {SupportsCreate = true, SupportsPopulate = true, AutoPopulate = true, AutoDetectConstructor = true};
+            var firstCapability = Substitute.For<IBuildCapability>();
+            var secondCapability = Substitute.For<IBuildCapability>();
 
             var firstAction = Substitute.For<IBuildAction>();
             var secondAction = Substitute.For<IBuildAction>();
@@ -822,46 +399,16 @@
             var buildChain = Substitute.For<IBuildChain>();
             var executeStrategy = Substitute.For<IExecuteStrategy>();
 
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MinValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(firstMatch);
-            secondAction.Priority.Returns(int.MaxValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(secondMatch);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, BuildRequirement.Create, type);
-
-            actual.Should().BeEquivalentTo(secondMatch);
-        }
-
-        [Fact]
-        public void GetBuildCapabilityForTypeReturnsValueFromMatchingAction()
-        {
-            var type = typeof(Person);
-            var firstMatch = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsCreate = false};
-            var secondMatch = new BuildCapability(typeof(DefaultTypeCreator))
-                {SupportsCreate = true, SupportsPopulate = true, AutoPopulate = true, AutoDetectConstructor = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
+            secondCapability.SupportsCreate.Returns(true);
+            secondCapability.SupportsPopulate.Returns(true);
+            secondCapability.AutoPopulate.Returns(true);
+            secondCapability.AutoDetectConstructor.Returns(true);
             executeStrategy.BuildChain.Returns(buildChain);
             executeStrategy.Configuration.Returns(buildConfiguration);
             firstAction.Priority.Returns(int.MaxValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(firstMatch);
+            firstAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(firstCapability);
             secondAction.Priority.Returns(int.MinValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(secondMatch);
+            secondAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(secondCapability);
 
             var actions = new List<IBuildAction>
             {
@@ -871,37 +418,58 @@
 
             var sut = new BuildProcessor(actions);
 
-            var actual = sut.GetBuildCapability(buildConfiguration, buildChain, BuildRequirement.Create, type);
+            var actual = sut.GetBuildCapability(executeStrategy, BuildRequirement.Create, type);
 
-            actual.Should().BeEquivalentTo(secondMatch);
+            actual.Should().BeEquivalentTo(secondCapability);
         }
 
         [Fact]
-        public void GetBuildCapabilityForTypeThrowsExceptionWithNullBuildChain()
+        public void GetBuildCapabilityForTypeReturnsCapabilityFromActionWithHighestPriority()
         {
-            var actions = Array.Empty<IBuildAction>();
             var type = typeof(Person);
+            var firstCapability = Substitute.For<IBuildCapability>();
+            var secondCapability = Substitute.For<IBuildCapability>();
 
+            var firstAction = Substitute.For<IBuildAction>();
+            var secondAction = Substitute.For<IBuildAction>();
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
+            var buildChain = Substitute.For<IBuildChain>();
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+
+            firstCapability.SupportsCreate.Returns(true);
+            secondCapability.SupportsCreate.Returns(true);
+            secondCapability.SupportsPopulate.Returns(true);
+            secondCapability.AutoPopulate.Returns(true);
+            secondCapability.AutoDetectConstructor.Returns(true);
+            executeStrategy.BuildChain.Returns(buildChain);
+            executeStrategy.Configuration.Returns(buildConfiguration);
+            firstAction.Priority.Returns(int.MinValue);
+            firstAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(firstCapability);
+            secondAction.Priority.Returns(int.MaxValue);
+            secondAction.GetBuildCapability(buildConfiguration, buildChain, type).Returns(secondCapability);
+
+            var actions = new List<IBuildAction>
+            {
+                firstAction,
+                secondAction
+            };
 
             var sut = new BuildProcessor(actions);
 
-            Action action = () => sut.GetBuildCapability(buildConfiguration, null!, BuildRequirement.Create, type);
+            var actual = sut.GetBuildCapability(executeStrategy, BuildRequirement.Create, type);
 
-            action.Should().Throw<ArgumentNullException>();
+            actual.Should().BeEquivalentTo(secondCapability);
         }
 
         [Fact]
-        public void GetBuildCapabilityForTypeThrowsExceptionWithNullBuildConfiguration()
+        public void GetBuildCapabilityForTypeThrowsExceptionWithNullExecuteStrategy()
         {
             var actions = Array.Empty<IBuildAction>();
             var type = typeof(Person);
 
-            var buildChain = Substitute.For<IBuildChain>();
-
             var sut = new BuildProcessor(actions);
 
-            Action action = () => sut.GetBuildCapability(null!, buildChain, BuildRequirement.Create, type);
+            Action action = () => sut.GetBuildCapability(null!, BuildRequirement.Create, type);
 
             action.Should().Throw<ArgumentNullException>();
         }
@@ -913,148 +481,14 @@
 
             var buildConfiguration = Substitute.For<IBuildConfiguration>();
             var buildChain = Substitute.For<IBuildChain>();
+            var executeStrategy = Substitute.For<IExecuteStrategy>();
+            executeStrategy.Configuration.Returns(buildConfiguration);
+            executeStrategy.BuildChain.Returns(buildChain);
 
             var sut = new BuildProcessor(actions);
 
             Action action = () =>
-                sut.GetBuildCapability(buildConfiguration, buildChain, BuildRequirement.Create, (Type) null!);
-
-            action.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void PopulateReturnsActionValue()
-        {
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsPopulate = true};
-
-            var action = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            action.GetBuildCapability(buildConfiguration, buildChain, expected.GetType()).Returns(match);
-            action.Populate(executeStrategy, expected).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                action
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Populate(executeStrategy, expected);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void PopulateReturnsValueFromActionWithHighestPriority()
-        {
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsPopulate = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MinValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, expected.GetType()).Returns(match);
-            secondAction.Priority.Returns(int.MaxValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, expected.GetType()).Returns(match);
-            secondAction.Populate(executeStrategy, expected).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Populate(executeStrategy, expected);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void PopulateReturnsValueFromMatchingAction()
-        {
-            var expected = new Person();
-            var match = new BuildCapability(typeof(DefaultTypeCreator)) {SupportsPopulate = true};
-
-            var firstAction = Substitute.For<IBuildAction>();
-            var secondAction = Substitute.For<IBuildAction>();
-            var buildConfiguration = Substitute.For<IBuildConfiguration>();
-            var buildChain = Substitute.For<IBuildChain>();
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            executeStrategy.BuildChain.Returns(buildChain);
-            executeStrategy.Configuration.Returns(buildConfiguration);
-            firstAction.Priority.Returns(int.MaxValue);
-            firstAction.GetBuildCapability(buildConfiguration, buildChain, expected.GetType())
-                .Returns((BuildCapability) null!);
-            secondAction.Priority.Returns(int.MinValue);
-            secondAction.GetBuildCapability(buildConfiguration, buildChain, expected.GetType()).Returns(match);
-            secondAction.Populate(executeStrategy, expected).Returns(expected);
-
-            var actions = new List<IBuildAction>
-            {
-                firstAction,
-                secondAction
-            };
-
-            var sut = new BuildProcessor(actions);
-
-            var actual = sut.Populate(executeStrategy, expected);
-
-            actual.Should().Be(expected);
-        }
-
-        [Fact]
-        public void PopulateThrowsExceptionWhenNoBuildActionFound()
-        {
-            var actions = Array.Empty<IBuildAction>();
-            var instance = new Person();
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Populate(executeStrategy, instance);
-
-            action.Should().Throw<NotSupportedException>();
-        }
-
-        [Fact]
-        public void PopulateThrowsExceptionWithNullExecuteStrategy()
-        {
-            var actions = Array.Empty<IBuildAction>();
-            var instance = new Person();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Populate(null!, instance);
-
-            action.Should().Throw<ArgumentNullException>();
-        }
-
-        [Fact]
-        public void PopulateThrowsExceptionWithNullInstance()
-        {
-            var actions = Array.Empty<IBuildAction>();
-
-            var executeStrategy = Substitute.For<IExecuteStrategy>();
-
-            var sut = new BuildProcessor(actions);
-
-            Action action = () => sut.Populate(executeStrategy, null!);
+                sut.GetBuildCapability(executeStrategy, BuildRequirement.Create, (Type) null!);
 
             action.Should().Throw<ArgumentNullException>();
         }

--- a/ModelBuilder/BuildActions/BuildCapability.cs
+++ b/ModelBuilder/BuildActions/BuildCapability.cs
@@ -1,50 +1,192 @@
 ﻿namespace ModelBuilder.BuildActions
 {
     using System;
+    using System.Reflection;
+    using ModelBuilder.CreationRules;
+    using ModelBuilder.TypeCreators;
+    using ModelBuilder.ValueGenerators;
 
     /// <summary>
     ///     The <see cref="BuildCapability" />
     ///     class is used to identify how <see cref="IExecuteStrategy" /> should operate when using
     ///     <see cref="IBuildProcessor" />.
     /// </summary>
-    public class BuildCapability
+    public class BuildCapability : IBuildCapability
     {
+        private readonly Func<IExecuteStrategy, ParameterInfo, object?[]?, object?> _createParameter;
+        private readonly Func<IExecuteStrategy, PropertyInfo, object?[]?, object?> _createProperty;
+        private readonly Func<IExecuteStrategy, Type, object?[]?, object?> _createType;
+        private readonly Func<IExecuteStrategy, object, object> _populate;
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="BuildCapability"/> class.
+        ///     Initializes a new instance of the <see cref="BuildCapability" /> class.
         /// </summary>
-        /// <param name="implementedByType">The type provide provides the implementation of the capability.</param>
-        public BuildCapability(Type implementedByType)
+        /// <param name="generator">The generator that provides the build functions.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="generator" /> parameter is <c>null</c>.</exception>
+        public BuildCapability(IValueGenerator generator)
         {
-            ImplementedByType = implementedByType ?? throw new ArgumentNullException(nameof(implementedByType));
+            if (generator == null)
+            {
+                throw new ArgumentNullException(nameof(generator));
+            }
+
+            ImplementedByType = generator.GetType();
+            SupportsCreate = true;
+
+            _createType = (strategy, type, args) => generator.Generate(strategy, type);
+            _createProperty = (strategy, propertyInfo, args) => generator.Generate(strategy, propertyInfo);
+            _createParameter = (strategy, parameterInfo, args) => generator.Generate(strategy, parameterInfo);
+            _populate = (strategy, instance) =>
+                throw new NotSupportedException(
+                    $"{nameof(IValueGenerator)} types do not support populating an instance.");
         }
 
         /// <summary>
-        ///     Gets or sets whether attempts to create the instance requires a constructor to be automatically resolved.
+        ///     Initializes a new instance of the <see cref="BuildCapability" /> class.
         /// </summary>
+        /// <param name="rule">The rule that provides the build functions.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="rule" /> parameter is <c>null</c>.</exception>
+        public BuildCapability(ICreationRule rule)
+        {
+            if (rule == null)
+            {
+                throw new ArgumentNullException(nameof(rule));
+            }
+
+            ImplementedByType = rule.GetType();
+            SupportsCreate = true;
+
+            _createType = (strategy, type, args) => rule.Create(strategy, type);
+            _createProperty = (strategy, propertyInfo, args) => rule.Create(strategy, propertyInfo);
+            _createParameter = (strategy, parameterInfo, args) => rule.Create(strategy, parameterInfo);
+            _populate = (strategy, instance) =>
+                throw new NotSupportedException(
+                    $"{nameof(ICreationRule)} types do not support populating an instance.");
+        }
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="BuildCapability" /> class.
+        /// </summary>
+        /// <param name="typeCreator">The type creator that provides the build functions.</param>
+        /// <param name="supportsCreate">
+        ///     <c>true</c> if the <paramref name="typeCreator" /> can create an instance; otherwise
+        ///     <c>false</c>.
+        /// </param>
+        /// <param name="supportsPopulate">
+        ///     <c>true</c> if the <paramref name="typeCreator" /> can populate an instance; otherwise
+        ///     <c>false</c>.
+        /// </param>
+        /// <exception cref="ArgumentNullException">The <paramref name="typeCreator" /> parameter is <c>null</c>.</exception>
+        public BuildCapability(ITypeCreator typeCreator, bool supportsCreate, bool supportsPopulate)
+        {
+            if (typeCreator == null)
+            {
+                throw new ArgumentNullException(nameof(typeCreator));
+            }
+
+            ImplementedByType = typeCreator.GetType();
+            SupportsCreate = supportsCreate;
+            SupportsPopulate = supportsPopulate;
+            AutoPopulate = typeCreator.AutoPopulate;
+            AutoDetectConstructor = typeCreator.AutoDetectConstructor;
+
+            _createType = typeCreator.Create;
+            _createProperty = typeCreator.Create;
+            _createParameter = typeCreator.Create;
+            _populate = typeCreator.Populate;
+        }
+
+        /// <inheritdoc />
+        /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="parameterInfo" /> parameter is <c>null</c>.</exception>
+        public object? CreateParameter(IExecuteStrategy executeStrategy, ParameterInfo parameterInfo,
+            object?[]? args)
+        {
+            if (executeStrategy == null)
+            {
+                throw new ArgumentNullException(nameof(executeStrategy));
+            }
+
+            if (parameterInfo == null)
+            {
+                throw new ArgumentNullException(nameof(parameterInfo));
+            }
+
+            return _createParameter(executeStrategy, parameterInfo, args);
+        }
+
+        /// <inheritdoc />
+        /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="propertyInfo" /> parameter is <c>null</c>.</exception>
+        public object? CreateProperty(IExecuteStrategy executeStrategy, PropertyInfo propertyInfo,
+            object?[]? args)
+        {
+            if (executeStrategy == null)
+            {
+                throw new ArgumentNullException(nameof(executeStrategy));
+            }
+
+            if (propertyInfo == null)
+            {
+                throw new ArgumentNullException(nameof(propertyInfo));
+            }
+
+            return _createProperty(executeStrategy, propertyInfo, args);
+        }
+
+        /// <inheritdoc />
+        /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="targetType" /> parameter is <c>null</c>.</exception>
+        public object? CreateType(IExecuteStrategy executeStrategy, Type targetType, object?[]? args)
+        {
+            if (executeStrategy == null)
+            {
+                throw new ArgumentNullException(nameof(executeStrategy));
+            }
+
+            if (targetType == null)
+            {
+                throw new ArgumentNullException(nameof(targetType));
+            }
+
+            return _createType(executeStrategy, targetType, args);
+        }
+
+        /// <inheritdoc />
+        /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="instance" /> parameter is <c>null</c>.</exception>
+        public object Populate(IExecuteStrategy executeStrategy, object instance)
+        {
+            if (executeStrategy == null)
+            {
+                throw new ArgumentNullException(nameof(executeStrategy));
+            }
+
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            return _populate(executeStrategy, instance);
+        }
+
+        /// <inheritdoc />
         /// <remarks>
-        ///     When set to <c>true</c>, detection of the appropriate constructor and creation of constructor parameters will
+        ///     When <c>true</c>, detection of the appropriate constructor and creation of constructor parameters will
         ///     be required.
         /// </remarks>
-        public bool AutoDetectConstructor { get; set; }
+        public bool AutoDetectConstructor { get; }
 
-        /// <summary>
-        ///     Gets or sets whether properties on the created value should be automatically populated.
-        /// </summary>
-        public bool AutoPopulate { get; set; }
+        /// <inheritdoc />
+        public bool AutoPopulate { get; }
 
-        /// <summary>
-        ///     Gets or sets the type that will be used to run a create or populate process.
-        /// </summary>
+        /// <inheritdoc />
         public Type ImplementedByType { get; }
 
-        /// <summary>
-        ///     Gets or sets whether there the <see cref="IBuildAction" /> supports the requested scenario.
-        /// </summary>
-        public bool SupportsCreate { get; set; }
+        /// <inheritdoc />
+        public bool SupportsCreate { get; }
 
-        /// <summary>
-        ///     Gets or sets whether a build action supports populating the created value with its own logic.
-        /// </summary>
-        public bool SupportsPopulate { get; set; }
+        /// <inheritdoc />
+        public bool SupportsPopulate { get; }
     }
 }

--- a/ModelBuilder/BuildActions/CreationRuleBuildAction.cs
+++ b/ModelBuilder/BuildActions/CreationRuleBuildAction.cs
@@ -82,7 +82,7 @@
         /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="type" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             Type type)
         {
             if (buildConfiguration == null)
@@ -107,7 +107,7 @@
         /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="parameterInfo" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             ParameterInfo parameterInfo)
         {
             if (buildConfiguration == null)
@@ -132,7 +132,7 @@
         /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="propertyInfo" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             PropertyInfo propertyInfo)
         {
             if (buildConfiguration == null)
@@ -202,7 +202,7 @@
             }
         }
 
-        private static BuildCapability? GetBuildCapability(Func<ICreationRule, bool> isMatch,
+        private static IBuildCapability? GetBuildCapability(Func<ICreationRule, bool> isMatch,
             IBuildConfiguration buildConfiguration)
         {
             var rule = GetMatchingRule(isMatch, buildConfiguration);
@@ -212,10 +212,7 @@
                 return null;
             }
 
-            return new BuildCapability(rule.GetType())
-            {
-                SupportsCreate = true
-            };
+            return new BuildCapability(rule);
         }
 
         private static ICreationRule? GetMatchingRule(Func<ICreationRule, bool> isMatch,

--- a/ModelBuilder/BuildActions/IBuildAction.cs
+++ b/ModelBuilder/BuildActions/IBuildAction.cs
@@ -43,7 +43,7 @@
         /// <param name="buildChain">The build chain.</param>
         /// <param name="type">The type to evaluate.</param>
         /// <returns>A <see cref="BuildCapability" /> indicating instance creation support via a <see cref="IBuildAction" />.</returns>
-        BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain, Type type);
+        IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain, Type type);
 
         /// <summary>
         ///     Gets the build capabilities of the build step for the specified parameter.
@@ -52,7 +52,7 @@
         /// <param name="buildChain">The build chain.</param>
         /// <param name="parameterInfo">The parameter to evaluate.</param>
         /// <returns>A <see cref="BuildCapability" /> indicating instance creation support via a <see cref="IBuildAction" />.</returns>
-        BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             ParameterInfo parameterInfo);
 
         /// <summary>
@@ -62,7 +62,7 @@
         /// <param name="buildChain">The build chain.</param>
         /// <param name="propertyInfo">The property to evaluate.</param>
         /// <returns>A <see cref="BuildCapability" /> indicating instance creation support via a <see cref="IBuildAction" />.</returns>
-        BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             PropertyInfo propertyInfo);
 
         /// <summary>

--- a/ModelBuilder/BuildActions/IBuildCapability.cs
+++ b/ModelBuilder/BuildActions/IBuildCapability.cs
@@ -1,0 +1,72 @@
+﻿namespace ModelBuilder.BuildActions
+{
+    using System;
+    using System.Reflection;
+
+    /// <summary>
+    ///     The <see cref="IBuildCapability" />
+    ///     interface defines the members for describing value creation support and creating instances.
+    /// </summary>
+    public interface IBuildCapability
+    {
+        /// <summary>
+        ///     Creates an instance of the type with the specified arguments.
+        /// </summary>
+        /// <param name="executeStrategy">The execution strategy.</param>
+        /// <param name="parameterInfo">The parameter to evaluate.</param>
+        /// <param name="args">The constructor parameters to create the instance with.</param>
+        /// <returns>A new instance.</returns>
+        object? CreateParameter(IExecuteStrategy executeStrategy, ParameterInfo parameterInfo, object?[]? args);
+
+        /// <summary>
+        ///     Creates an instance of the type with the specified arguments.
+        /// </summary>
+        /// <param name="executeStrategy">The execution strategy.</param>
+        /// <param name="propertyInfo">The property to evaluate.</param>
+        /// <param name="args">The constructor parameters to create the instance with.</param>
+        /// <returns>A new instance.</returns>
+        object? CreateProperty(IExecuteStrategy executeStrategy, PropertyInfo propertyInfo, object?[]? args);
+
+        /// <summary>
+        ///     Creates an instance of the type with the specified arguments.
+        /// </summary>
+        /// <param name="executeStrategy">The execution strategy.</param>
+        /// <param name="targetType">The type of instance to create.</param>
+        /// <param name="args">The constructor parameters to create the instance with.</param>
+        /// <returns>A new instance.</returns>
+        object? CreateType(IExecuteStrategy executeStrategy, Type targetType, object?[]? args);
+
+        /// <summary>
+        ///     Populates the specified instance using an execution strategy.
+        /// </summary>
+        /// <param name="executeStrategy">The execution strategy.</param>
+        /// <param name="instance">The instance to populate.</param>
+        /// <returns>The populated instance.</returns>
+        object Populate(IExecuteStrategy executeStrategy, object instance);
+
+        /// <summary>
+        ///     Gets whether attempts to create the instance requires a constructor to be automatically resolved.
+        /// </summary>
+        bool AutoDetectConstructor { get; }
+
+        /// <summary>
+        ///     Gets whether properties on the created value should be automatically populated.
+        /// </summary>
+        bool AutoPopulate { get; }
+
+        /// <summary>
+        ///     Gets the type that will be used to run a create or populate process.
+        /// </summary>
+        Type ImplementedByType { get; }
+
+        /// <summary>
+        ///     Gets whether there the <see cref="IBuildAction" /> supports the requested scenario.
+        /// </summary>
+        bool SupportsCreate { get; }
+
+        /// <summary>
+        ///     Gets whether a build action supports populating the created value with its own logic.
+        /// </summary>
+        bool SupportsPopulate { get; }
+    }
+}

--- a/ModelBuilder/BuildActions/TypeCreatorBuildAction.cs
+++ b/ModelBuilder/BuildActions/TypeCreatorBuildAction.cs
@@ -90,7 +90,7 @@
         /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="type" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             Type type)
         {
             if (buildConfiguration == null)
@@ -117,7 +117,7 @@
         /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="parameterInfo" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             ParameterInfo parameterInfo)
         {
             if (buildConfiguration == null)
@@ -144,7 +144,7 @@
         /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="propertyInfo" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             PropertyInfo propertyInfo)
         {
             if (buildConfiguration == null)
@@ -234,7 +234,7 @@
             }
         }
 
-        private static BuildCapability? GetBuildCapability(Func<ITypeCreator, bool> canCreate,
+        private static IBuildCapability? GetBuildCapability(Func<ITypeCreator, bool> canCreate,
             Func<ITypeCreator, bool> canPopulate, IBuildConfiguration buildConfiguration)
         {
             var typeCreator = GetMatchingTypeCreator(canCreate, buildConfiguration);
@@ -244,16 +244,10 @@
                 return null;
             }
 
-            var canCreateValue = canCreate(typeCreator);
-            var canPopulateValue = canPopulate(typeCreator);
+            var supportsCreate = canCreate(typeCreator);
+            var supportsPopulate = canPopulate(typeCreator);
 
-            return new BuildCapability(typeCreator.GetType())
-            {
-                SupportsCreate = canCreateValue,
-                SupportsPopulate = canPopulateValue,
-                AutoPopulate = typeCreator.AutoPopulate,
-                AutoDetectConstructor = typeCreator.AutoDetectConstructor
-            };
+            return new BuildCapability(typeCreator, supportsCreate, supportsPopulate);
         }
 
         private static ITypeCreator? GetMatchingTypeCreator(Func<ITypeCreator, bool> canCreate,

--- a/ModelBuilder/BuildActions/ValueGeneratorBuildAction.cs
+++ b/ModelBuilder/BuildActions/ValueGeneratorBuildAction.cs
@@ -82,7 +82,7 @@
         /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="type" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             Type type)
         {
             if (buildConfiguration == null)
@@ -107,7 +107,7 @@
         /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="parameterInfo" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             ParameterInfo parameterInfo)
         {
             if (buildConfiguration == null)
@@ -132,7 +132,7 @@
         /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="propertyInfo" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
             PropertyInfo propertyInfo)
         {
             if (buildConfiguration == null)
@@ -203,7 +203,7 @@
             }
         }
 
-        private static BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration,
+        private static IBuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration,
             Func<IValueGenerator, bool> isMatch)
         {
             var generator = GetMatchingGenerator(buildConfiguration, isMatch);
@@ -213,10 +213,7 @@
                 return null;
             }
 
-            return new BuildCapability(generator.GetType())
-            {
-                SupportsCreate = true
-            };
+            return new BuildCapability(generator);
         }
 
         private static IValueGenerator? GetMatchingGenerator(IBuildConfiguration buildConfiguration,

--- a/ModelBuilder/BuildProcessor.cs
+++ b/ModelBuilder/BuildProcessor.cs
@@ -41,97 +41,12 @@
         /// <inheritdoc />
         /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="type" /> parameter is <c>null</c>.</exception>
-        public object? Build(IExecuteStrategy executeStrategy, Type type, params object?[]? arguments)
-        {
-            if (executeStrategy == null)
-            {
-                throw new ArgumentNullException(nameof(executeStrategy));
-            }
-
-            if (type == null)
-            {
-                throw new ArgumentNullException(nameof(type));
-            }
-
-            var match = GetMatch(BuildRequirement.Create, x => x.GetBuildCapability(executeStrategy.Configuration,
-                executeStrategy.BuildChain,
-                type));
-
-            if (match == null)
-            {
-                throw new NotSupportedException();
-            }
-
-            return match.Action.Build(executeStrategy, type, arguments);
-        }
-
-        /// <inheritdoc />
-        /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="parameterInfo" /> parameter is <c>null</c>.</exception>
-        public object? Build(IExecuteStrategy executeStrategy, ParameterInfo parameterInfo, params object?[]? arguments)
-        {
-            if (executeStrategy == null)
-            {
-                throw new ArgumentNullException(nameof(executeStrategy));
-            }
-
-            if (parameterInfo == null)
-            {
-                throw new ArgumentNullException(nameof(parameterInfo));
-            }
-
-            var match = GetMatch(BuildRequirement.Create, x => x.GetBuildCapability(executeStrategy.Configuration,
-                executeStrategy.BuildChain, parameterInfo));
-
-            if (match == null)
-            {
-                throw new NotSupportedException();
-            }
-
-            return match.Action.Build(executeStrategy, parameterInfo, arguments);
-        }
-
-        /// <inheritdoc />
-        /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="propertyInfo" /> parameter is <c>null</c>.</exception>
-        public object? Build(IExecuteStrategy executeStrategy, PropertyInfo propertyInfo, params object?[]? arguments)
-        {
-            if (executeStrategy == null)
-            {
-                throw new ArgumentNullException(nameof(executeStrategy));
-            }
-
-            if (propertyInfo == null)
-            {
-                throw new ArgumentNullException(nameof(propertyInfo));
-            }
-
-            var match = GetMatch(BuildRequirement.Create, x => x.GetBuildCapability(executeStrategy.Configuration,
-                executeStrategy.BuildChain, propertyInfo));
-
-            if (match == null)
-            {
-                throw new NotSupportedException();
-            }
-
-            return match.Action.Build(executeStrategy, propertyInfo, arguments);
-        }
-
-        /// <inheritdoc />
-        /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="type" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability GetBuildCapability(IExecuteStrategy executeStrategy,
             BuildRequirement buildRequirement, Type type)
         {
-            if (buildConfiguration == null)
+            if (executeStrategy == null)
             {
-                throw new ArgumentNullException(nameof(buildConfiguration));
-            }
-
-            if (buildChain == null)
-            {
-                throw new ArgumentNullException(nameof(buildChain));
+                throw new ArgumentNullException(nameof(executeStrategy));
             }
 
             if (type == null)
@@ -139,29 +54,23 @@
                 throw new ArgumentNullException(nameof(type));
             }
 
-            var match = GetMatch(buildRequirement, x => x.GetBuildCapability(buildConfiguration,
-                buildChain,
-                type));
+            var match = GetCapability(executeStrategy, buildRequirement, x => x.GetBuildCapability(
+                executeStrategy.Configuration, executeStrategy.BuildChain,
+                type), type, null);
 
-            return match?.Capability;
+            return match;
         }
 
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="parameterInfo" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability GetBuildCapability(IExecuteStrategy executeStrategy,
             BuildRequirement buildRequirement,
             ParameterInfo parameterInfo)
         {
-            if (buildConfiguration == null)
+            if (executeStrategy == null)
             {
-                throw new ArgumentNullException(nameof(buildConfiguration));
-            }
-
-            if (buildChain == null)
-            {
-                throw new ArgumentNullException(nameof(buildChain));
+                throw new ArgumentNullException(nameof(executeStrategy));
             }
 
             if (parameterInfo == null)
@@ -169,29 +78,23 @@
                 throw new ArgumentNullException(nameof(parameterInfo));
             }
 
-            var match = GetMatch(buildRequirement, x => x.GetBuildCapability(buildConfiguration,
-                buildChain,
-                parameterInfo));
+            var match = GetCapability(executeStrategy, buildRequirement, x => x.GetBuildCapability(
+                executeStrategy.Configuration, executeStrategy.BuildChain,
+                parameterInfo), parameterInfo.ParameterType, parameterInfo.Name);
 
-            return match?.Capability;
+            return match;
         }
 
         /// <inheritdoc />
-        /// <exception cref="ArgumentNullException">The <paramref name="buildConfiguration" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="buildChain" /> parameter is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="propertyInfo" /> parameter is <c>null</c>.</exception>
-        public BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        public IBuildCapability GetBuildCapability(IExecuteStrategy executeStrategy,
             BuildRequirement buildRequirement,
             PropertyInfo propertyInfo)
         {
-            if (buildConfiguration == null)
+            if (executeStrategy == null)
             {
-                throw new ArgumentNullException(nameof(buildConfiguration));
-            }
-
-            if (buildChain == null)
-            {
-                throw new ArgumentNullException(nameof(buildChain));
+                throw new ArgumentNullException(nameof(executeStrategy));
             }
 
             if (propertyInfo == null)
@@ -199,66 +102,36 @@
                 throw new ArgumentNullException(nameof(propertyInfo));
             }
 
-            var match = GetMatch(buildRequirement, x => x.GetBuildCapability(buildConfiguration,
-                buildChain,
-                propertyInfo));
+            var match = GetCapability(executeStrategy, buildRequirement, x => x.GetBuildCapability(
+                executeStrategy.Configuration, executeStrategy.BuildChain,
+                propertyInfo), propertyInfo.PropertyType, propertyInfo.Name);
 
-            return match?.Capability;
+            return match;
         }
 
-        /// <inheritdoc />
-        /// <exception cref="ArgumentNullException">The <paramref name="executeStrategy" /> parameter is <c>null</c>.</exception>
-        /// <exception cref="ArgumentNullException">The <paramref name="instance" /> parameter is <c>null</c>.</exception>
-        public object Populate(IExecuteStrategy executeStrategy, object instance)
-        {
-            if (executeStrategy == null)
-            {
-                throw new ArgumentNullException(nameof(executeStrategy));
-            }
-
-            if (instance == null)
-            {
-                throw new ArgumentNullException(nameof(instance));
-            }
-
-            var match = GetMatch(BuildRequirement.Populate, x => x.GetBuildCapability(executeStrategy.Configuration,
-                executeStrategy.BuildChain, instance.GetType()));
-
-            if (match == null)
-            {
-                throw new NotSupportedException();
-            }
-
-            return match.Action.Populate(executeStrategy, instance);
-        }
-
-        private Match? GetMatch(BuildRequirement buildRequirement, Func<IBuildAction, BuildCapability?> evaluator)
+        private IBuildCapability GetCapability(IExecuteStrategy executeStrategy, BuildRequirement buildRequirement,
+            Func<IBuildAction, IBuildCapability?> evaluator, Type targetType, string? referenceName)
         {
             var capabilities = from x in _actions
                 orderby x.Priority descending
-                select new Match(x)
-                {
-                    Capability = evaluator(x)
-                };
+                select evaluator(x);
 
             var matches = from x in capabilities
-                where x.Capability != null
-                      && (x.Capability.SupportsCreate && buildRequirement == BuildRequirement.Create
-                          || x.Capability.SupportsPopulate && buildRequirement == BuildRequirement.Populate)
+                where x != null
+                      && (x.SupportsCreate && buildRequirement == BuildRequirement.Create
+                          || x.SupportsPopulate && buildRequirement == BuildRequirement.Populate)
                 select x;
 
-            return matches.FirstOrDefault();
-        }
+            var capability = matches.FirstOrDefault();
 
-        private class Match
-        {
-            public Match(IBuildAction action)
+            if (capability == null)
             {
-                Action = action;
+                var message = $"Failed to identify build capabilities for {targetType.FullName}.";
+
+                throw new BuildException(message, targetType, referenceName, null, executeStrategy.Log.Output);
             }
 
-            public IBuildAction Action { get; }
-            public BuildCapability? Capability { get; set; }
+            return capability;
         }
     }
 }

--- a/ModelBuilder/IBuildProcessor.cs
+++ b/ModelBuilder/IBuildProcessor.cs
@@ -11,73 +11,35 @@
     public interface IBuildProcessor
     {
         /// <summary>
-        ///     Builds a value of the specified type.
-        /// </summary>
-        /// <param name="executeStrategy">The execute strategy.</param>
-        /// <param name="type">The type of value to build.</param>
-        /// <param name="arguments">The constructor parameters to create the instance with.</param>
-        /// <returns>The new value.</returns>
-        object? Build(IExecuteStrategy executeStrategy, Type type, params object?[]? arguments);
-
-        /// <summary>
-        ///     Builds a value of the specified type.
-        /// </summary>
-        /// <param name="executeStrategy">The execute strategy.</param>
-        /// <param name="parameterInfo">The parameter of value to build.</param>
-        /// <param name="arguments">The constructor parameters to create the instance with.</param>
-        /// <returns>The new value.</returns>
-        object? Build(IExecuteStrategy executeStrategy, ParameterInfo parameterInfo, params object?[]? arguments);
-
-        /// <summary>
-        ///     Builds a value of the specified type.
-        /// </summary>
-        /// <param name="executeStrategy">The execute strategy.</param>
-        /// <param name="propertyInfo">The property of value to build.</param>
-        /// <param name="arguments">The constructor parameters to create the instance with.</param>
-        /// <returns>The new value.</returns>
-        object? Build(IExecuteStrategy executeStrategy, PropertyInfo propertyInfo, params object?[]? arguments);
-
-        /// <summary>
         ///     Gets the build capability for the specified type.
         /// </summary>
-        /// <param name="buildConfiguration">The build configuration.</param>
-        /// <param name="buildChain">The build chain.</param>
+        /// <param name="executeStrategy">The execute strategy.</param>
         /// <param name="buildRequirement">The build capability.</param>
         /// <param name="type">The type to evaluate.</param>
         /// <returns>A <see cref="BuildCapability" /> indicating instance creation support via a <see cref="IBuildAction" />.</returns>
-        BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        IBuildCapability GetBuildCapability(IExecuteStrategy executeStrategy,
             BuildRequirement buildRequirement, Type type);
 
         /// <summary>
         ///     Gets the build capability for the specified parameter.
         /// </summary>
-        /// <param name="buildConfiguration">The build configuration.</param>
-        /// <param name="buildChain">The build chain.</param>
+        /// <param name="executeStrategy">The execute strategy.</param>
         /// <param name="buildRequirement">The build capability.</param>
         /// <param name="parameterInfo">The parameter to evaluate.</param>
         /// <returns>A <see cref="BuildCapability" /> indicating instance creation support via a <see cref="IBuildAction" />.</returns>
-        BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        IBuildCapability GetBuildCapability(IExecuteStrategy executeStrategy,
             BuildRequirement buildRequirement,
             ParameterInfo parameterInfo);
 
         /// <summary>
         ///     Gets the build capability for the specified property.
         /// </summary>
-        /// <param name="buildConfiguration">The build configuration.</param>
-        /// <param name="buildChain">The build chain.</param>
+        /// <param name="executeStrategy">The execute strategy.</param>
         /// <param name="buildRequirement">The build capability.</param>
         /// <param name="propertyInfo">The property to evaluate.</param>
         /// <returns>A <see cref="BuildCapability" /> indicating instance creation support via a <see cref="IBuildAction" />.</returns>
-        BuildCapability? GetBuildCapability(IBuildConfiguration buildConfiguration, IBuildChain buildChain,
+        IBuildCapability GetBuildCapability(IExecuteStrategy executeStrategy,
             BuildRequirement buildRequirement,
             PropertyInfo propertyInfo);
-
-        /// <summary>
-        ///     Populates the specified instance using an execution strategy.
-        /// </summary>
-        /// <param name="executeStrategy">The execution strategy.</param>
-        /// <param name="instance">The instance to populate.</param>
-        /// <returns>The populated instance.</returns>
-        object Populate(IExecuteStrategy executeStrategy, object instance);
     }
 }


### PR DESCRIPTION
Refactored BuildCapability to include a wrapper for the underlying create/populate logic

Removed Create/Populate logic from BuildProcessor as the returned BuildCapability now exposes this to DefaultExecuteStrategy