### PR TITLE
internal constructor implementation

### DIFF
--- a/ModelBuilder.UnitTests/DefaultConstructorResolverTests.cs
+++ b/ModelBuilder.UnitTests/DefaultConstructorResolverTests.cs
@@ -216,7 +216,7 @@
         [InlineData(typeof(Gender))]
         [InlineData(typeof(Copy))]
         [InlineData(typeof(Clone))]
-        public void ResolveReturnsNullForTypesWithoutPublicConstructors(Type targetType)
+        public void ResolveReturnsNullForTypesWithoutPublicOrInternalConstructors(Type targetType)
         {
             var sut = new DefaultConstructorResolver(CacheLevel.PerInstance);
 

--- a/ModelBuilder.UnitTests/ModelTests.cs
+++ b/ModelBuilder.UnitTests/ModelTests.cs
@@ -1,9 +1,9 @@
 ﻿namespace ModelBuilder.UnitTests
 {
-    using System;
-    using System.Linq;
     using FluentAssertions;
     using ModelBuilder.UnitTests.Models;
+    using System;
+    using System.Linq;
     using Xunit;
     using Xunit.Abstractions;
 
@@ -14,6 +14,15 @@
         public ModelTests(ITestOutputHelper output)
         {
             _output = output;
+        }
+
+        [Fact]
+        public void CreateWithInternalConstructorReturnsInstance()
+        {
+            var model = Model.Create<EntityWithInternalConstructor>();
+            model.Should().NotBeNull();
+            model.EntityId.Should().NotBeEmpty();
+            model.EntityName.Should().NotBeNullOrWhiteSpace();
         }
 
         [Fact]

--- a/ModelBuilder.UnitTests/Models/EntityWithInternalConstructor.cs
+++ b/ModelBuilder.UnitTests/Models/EntityWithInternalConstructor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace ModelBuilder.UnitTests.Models
+{
+    public class EntityWithInternalConstructor
+    {
+        internal EntityWithInternalConstructor(Guid entityId, string entityName)
+        {
+            EntityId = entityId;
+            EntityName = entityName;
+        }
+
+        public Guid EntityId { get; }
+
+        public string EntityName { get; }
+    }
+}

--- a/ModelBuilder/TypeCreators/ArrayTypeCreator.cs
+++ b/ModelBuilder/TypeCreators/ArrayTypeCreator.cs
@@ -1,6 +1,7 @@
 ﻿namespace ModelBuilder.TypeCreators
 {
     using System;
+    using System.Reflection;
 
     /// <summary>
     ///     The <see cref="ArrayTypeCreator" />
@@ -71,7 +72,9 @@
 
             if (constructor == null)
             {
-                throw new BuildException($"No constructor was found that matches the parameters (int)");
+                constructor = type.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, parameterTypes, null);
+                if(constructor == null || (constructor.Attributes & MethodAttributes.Assembly) != MethodAttributes.Assembly)
+                    throw new BuildException($"No constructor was found that matches the parameters (int)");
             }
 
             return constructor.Invoke(parameters);


### PR DESCRIPTION
Changed ConstructorResolver and TypeResolver to handle internal constructors.
public constructors will be used by default and if none are found that fulfil then the resolvers will try to retrieve internal constructors with the same signatures