### PR TITLE
The GuidValueGenerator has different behaviour to other nullable generators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         targetdir: "Report"
         reporttypes: "HtmlInline;Cobertura"
         tag: '${{ github.run_number }}_${{ github.run_id }}'
-      if: github.event_name == 'pull_request' && github.repository_owner == 'roryprimrose'       # Don't run on forks
+      if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name       # Don't run on forks
 
     - name: Publish coverage report
       uses: 5monkeys/cobertura-action@master
@@ -83,7 +83,7 @@ jobs:
         path: Report/Cobertura.xml
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         minimum_coverage: 75
-      if: github.event_name == 'pull_request' && github.repository_owner == 'roryprimrose'       # Don't run on forks
+      if: github.event_name == 'pull_request' && github.repository == github.event.pull_request.head.repo.full_name       # Don't run on forks
       
     - name: Resolve project name
       shell: pwsh
@@ -111,7 +111,8 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'roryprimrose'       # Don't run on forks
+    # Only run on pushes which should only be on the base repository
+    if: github.event_name == 'push'
 
     steps:
     - name: Download packages
@@ -130,7 +131,8 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'roryprimrose' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
+    # Only run on pushes which should only be on the base repository and only where the branch is master or is a version tagged build
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v'))
 
     steps:
     

--- a/ModelBuilder.UnitTests/ValueGenerators/GuidValueGeneratorTests.cs
+++ b/ModelBuilder.UnitTests/ValueGenerators/GuidValueGeneratorTests.cs
@@ -19,11 +19,14 @@
             var nullFound = false;
             var valueFound = false;
 
-            var sut = new Wrapper();
+            var sut = new GuidValueGenerator
+            {
+                AllowNull = true
+            };
 
             for (var index = 0; index < 1000; index++)
             {
-                var value = (Guid?) sut.RunGenerate(typeof(Guid?), null!, executeStrategy);
+                var value = (Guid?)sut.Generate(executeStrategy, typeof(Guid?));
 
                 if (value == null!)
                 {
@@ -42,6 +45,14 @@
 
             nullFound.Should().BeTrue();
             valueFound.Should().BeTrue();
+        }
+
+        [Fact]
+        public void AllowNullReturnsFalseByDefault()
+        {
+            var sut = new GuidValueGenerator();
+
+            sut.AllowNull.Should().BeFalse();
         }
 
         [Fact]
@@ -70,13 +81,13 @@
 
             var sut = new Wrapper();
 
-            var first = (Guid) sut.RunGenerate(typeof(Guid), null!, executeStrategy);
+            var first = (Guid)sut.RunGenerate(typeof(Guid), null!, executeStrategy);
 
             var second = first;
 
             for (var index = 0; index < 1000; index++)
             {
-                second = (Guid) sut.RunGenerate(typeof(Guid), null!, executeStrategy);
+                second = (Guid)sut.RunGenerate(typeof(Guid), null!, executeStrategy);
 
                 if (first != second)
                 {

--- a/ModelBuilder/ValueGenerators/GuidValueGenerator.cs
+++ b/ModelBuilder/ValueGenerators/GuidValueGenerator.cs
@@ -6,7 +6,7 @@
     ///     The <see cref="GuidValueGenerator" />
     ///     class is used to generate <see cref="Guid" /> values.
     /// </summary>
-    public class GuidValueGenerator : ValueGeneratorMatcher
+    public class GuidValueGenerator : ValueGeneratorMatcher, INullableBuilder
     {
         /// <summary>
         ///     Initializes a new instance of the <see cref="GuidValueGenerator" /> class.
@@ -18,26 +18,23 @@
         /// <inheritdoc />
         protected override object? Generate(IExecuteStrategy executeStrategy, Type type, string? referenceName)
         {
-            if (type == typeof(Guid))
+            if (type == typeof(Guid) || AllowNull == false)
             {
                 return Guid.NewGuid();
             }
 
-            // Weight the random distribution so that it is roughly 5 times more likely to get a new guid than a null
-            var source = Generator.NextValue<double>(0, 5);
+            // Allow for a 10% the chance that this might be null
+            var range = Generator.NextValue(0, 100000);
 
-            Guid? value;
-
-            if (source < 1)
+            if (range < 10000)
             {
-                value = null;
-            }
-            else
-            {
-                value = Guid.NewGuid();
+                return null;
             }
 
-            return value;
+            return Guid.NewGuid();
         }
+
+        /// <inheritdoc />
+        public bool AllowNull { get; set; } = false;
     }
 }


### PR DESCRIPTION
Made changes to make it consistent in it's null generation policy.
Implemented INullableBuilder which exposes the AllowNull property.
Defaulted AllowNull to false to make consistent with other INullableBuilder implementation - note this has flipped the default behaviour of GuidValueGenerator and is potentially a breaking change.