### PR TITLE
Add Region and CountryRegion aliases for the country value source

### DIFF
--- a/ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs
+++ b/ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using FluentAssertions;
     using ModelBuilder;
     using ModelBuilder.Data;
@@ -122,6 +123,24 @@
             var actual = source!.Create(context, new BuildTarget(typeof(char)));
 
             char.IsLetterOrDigit(actual).Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("Country")]
+        [InlineData("Region")]
+        [InlineData("CountryRegion")]
+        public void CountrySourceMatchesRegionAliases(string memberName)
+        {
+            var registry = BuiltInValueSources.CreateNamedRegistry();
+            registry.TryGet<string>(memberName, out var source).Should().BeTrue();
+
+            var actual = source!.Create(
+                new BuildContext(new RandomSource(5)),
+                new BuildTarget(typeof(string), memberName));
+
+            // The value comes from the curated location data, proving the alias resolves to the country
+            // source rather than falling through to the generic string source.
+            TestData.Locations.Select(location => location.Country).Should().Contain(actual);
         }
 
         [Fact]

--- a/ModelBuilder/BuiltInValueSources.cs
+++ b/ModelBuilder/BuiltInValueSources.cs
@@ -51,7 +51,7 @@
             registry.Register(new DelegateValueSource<string>(NextEmail), "Email");
             registry.Register(new DelegateValueSource<string>(c => Pick(c, TestData.Domains)), _domainMembers);
             registry.Register(new DelegateValueSource<string>(c => Pick(c, TestData.Companies)), "Company", "Business");
-            registry.Register(new DelegateValueSource<string>(c => Location(c).Country), "Country");
+            registry.Register(new DelegateValueSource<string>(c => Location(c).Country), "Country", "Region", "CountryRegion");
             registry.Register(new DelegateValueSource<string>(c => Location(c).State), "State", "Province");
             registry.Register(new DelegateValueSource<string>(c => Location(c).City), "City", "Suburb", "Town");
             registry.Register(new DelegateValueSource<string>(c => Location(c).PostCode), "PostCode", "ZipCode", "Postcode", "Zip");


### PR DESCRIPTION
Fixes #345.

The country named value source only matched the member name `Country`. This adds `Region` and `CountryRegion` as aliases so members with those names resolve to a country value from the curated location data instead of a generic string.

Adds a theory test covering all three aliases (`Country`, `Region`, `CountryRegion`).