### PR TITLE
Apply ignore rules to applicable (assignable) types

### DIFF
--- a/ModelBuilder.UnitTests/BuildConfigurationTests.cs
+++ b/ModelBuilder.UnitTests/BuildConfigurationTests.cs
@@ -64,6 +64,36 @@
         }
 
         [Fact]
+        public void ShouldIgnoreAppliesRuleFromBaseTypeToDerivedType()
+        {
+            var sut = new BuildConfiguration();
+
+            sut.Ignore(typeof(Exception), "Message");
+
+            sut.ShouldIgnore(new MemberSignature(typeof(InvalidOperationException), "Message", typeof(string))).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ShouldIgnoreAppliesRuleFromInterfaceToImplementingType()
+        {
+            var sut = new BuildConfiguration();
+
+            sut.Ignore(typeof(IDisposable), "Tag");
+
+            sut.ShouldIgnore(new MemberSignature(typeof(MemoryStream), "Tag", typeof(string))).Should().BeTrue();
+        }
+
+        [Fact]
+        public void ShouldIgnoreDoesNotApplyRuleToUnrelatedType()
+        {
+            var sut = new BuildConfiguration();
+
+            sut.Ignore(typeof(MemoryStream), "Length");
+
+            sut.ShouldIgnore(new MemberSignature(typeof(Uri), "Length", typeof(int))).Should().BeFalse();
+        }
+
+        [Fact]
         public void ShouldIgnoreReturnsFalseWhenNoRulesRegistered()
         {
             var sut = new BuildConfiguration();

--- a/ModelBuilder/BuildConfiguration.cs
+++ b/ModelBuilder/BuildConfiguration.cs
@@ -100,6 +100,17 @@ namespace ModelBuilder
                 return true;
             }
 
+            // Honour a rule declared on a base type or interface of the member's declaring type so that an
+            // ignore rule keyed on a mapped-from or base type still applies when a more specific type is
+            // built (for example Ignoring<IShipment>(x => x.Data) when IShipment is mapped to Shipment).
+            foreach (var ignored in _ignoredMembers)
+            {
+                if (ignored.AppliesTo(member.DeclaringType, member.Name))
+                {
+                    return true;
+                }
+            }
+
             foreach (var predicate in _ignorePredicates)
             {
                 if (predicate(member))
@@ -168,6 +179,14 @@ namespace ModelBuilder
             {
                 _declaringType = declaringType;
                 _memberName = memberName;
+            }
+
+            public bool AppliesTo(Type declaringType, string memberName)
+            {
+                // The rule applies when the member name matches and the rule's type is the same as, or a
+                // base type or interface of, the type being built.
+                return string.Equals(_memberName, memberName, StringComparison.Ordinal)
+                       && _declaringType.IsAssignableFrom(declaringType);
             }
 
             public bool Equals(MemberKey other)


### PR DESCRIPTION
Fixes #146.

Ignore rules registered via `Ignore(type, name)` only matched the exact declaring type, so a rule keyed on a base type or interface (including a mapped-from type) did not apply when a more specific type was built.

`ShouldIgnore` now also matches when the rule's type is assignable from the member's declaring type, so `Ignoring<IShipment>(x => x.Data)` applies when `IShipment` is mapped to `Shipment`, and base-class rules apply to derived types. Exact-match and unrelated-type behaviour is unchanged.

Adds tests for the base-type, interface and unrelated-type cases.