### PR TITLE
Retain assigned member values during populate (#145)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 
@@ -106,7 +106,7 @@ jobs:
       run: dotnet pack "./${{ env.projectName }}/${{ env.projectName }}.csproj" -c Release --no-build --include-symbols -o $GITHUB_WORKSPACE/staging
 
     - name: Publish build artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: packages
         path: staging
@@ -116,7 +116,7 @@ jobs:
       run: |
         echo '${{ steps.gitversion.outputs.SemVer }}' > version.txt
     - name: Upload version
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: version
         path: version.txt
@@ -129,7 +129,7 @@ jobs:
 
     steps:
     - name: Download packages
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         name: packages
       
@@ -157,12 +157,12 @@ jobs:
     steps:
     
     - name: Download packages
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         name: packages
       
     - name: Download version
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v8
       with:
         name: version
 

--- a/ModelBuilder.Generator.UnitTests/GeneratedConstructionExecutionTests.cs
+++ b/ModelBuilder.Generator.UnitTests/GeneratedConstructionExecutionTests.cs
@@ -635,7 +635,7 @@ namespace Sample
         }
 
         [Fact]
-        public void PopulateRetainsAssignedMemberValueByDefault()
+        public void PopulateRetainsAssignedMemberValueWhenEnabled()
         {
             const string source = @"
 using ModelBuilder;
@@ -647,6 +647,42 @@ namespace Sample
         public string Preset { get; set; } = ""kept"";
 
         public string? Generated { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Holder Build()
+        {
+            var instance = new Holder();
+
+            return global::ModelBuilder.Model.SetOptions(o => o.RetainAssignedValues = true).Populate(instance);
+        }
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
+            var holder = InvokeCaller(assembly);
+
+            // With the option on, the pre-assigned member is retained while the default member is still generated.
+            holderType.GetProperty("Preset")!.GetValue(holder).Should().Be("kept");
+            holderType.GetProperty("Generated")!.GetValue(holder).Should().NotBeNull();
+        }
+
+        [Fact]
+        public void PopulateOverwritesAssignedMemberByDefault()
+        {
+            const string source = @"
+using ModelBuilder;
+
+namespace Sample
+{
+    public sealed class Holder
+    {
+        public string Preset { get; set; } = ""kept"";
     }
 
     public static class Caller
@@ -667,32 +703,36 @@ namespace Sample
             var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
             var holder = InvokeCaller(assembly);
 
-            // The pre-assigned member is retained while the default member is still generated.
-            holderType.GetProperty("Preset")!.GetValue(holder).Should().Be("kept");
-            holderType.GetProperty("Generated")!.GetValue(holder).Should().NotBeNull();
+            // By default the pre-assigned value is overwritten with a generated value.
+            holderType.GetProperty("Preset")!.GetValue(holder).Should().NotBe("kept");
         }
 
         [Fact]
-        public void PopulateOverwritesAssignedMemberWhenRetainDisabled()
+        public void CreatePopulatesAssignedMemberByDefault()
         {
             const string source = @"
 using ModelBuilder;
 
 namespace Sample
 {
+    public sealed class Detail
+    {
+        public string? Name { get; set; }
+    }
+
     public sealed class Holder
     {
-        public string Preset { get; set; } = ""kept"";
+        public Holder()
+        {
+            Detail = new Detail();
+        }
+
+        public Detail Detail { get; set; }
     }
 
     public static class Caller
     {
-        public static Holder Build()
-        {
-            var instance = new Holder();
-
-            return global::ModelBuilder.Model.SetOptions(o => o.RetainAssignedValues = false).Populate(instance);
-        }
+        public static Holder Build() => global::ModelBuilder.Model.Create<Holder>();
     }
 }";
 
@@ -701,14 +741,18 @@ namespace Sample
 
             var assembly = harness.EmitAndLoad();
             var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
+            var detailType = assembly.GetType("Sample.Detail", throwOnError: true)!;
             var holder = InvokeCaller(assembly);
 
-            // With retention disabled the pre-assigned value is overwritten with a generated value.
-            holderType.GetProperty("Preset")!.GetValue(holder).Should().NotBe("kept");
+            // By default a member assigned a newly constructed instance is still populated, so its own
+            // members are not left unset.
+            var detail = holderType.GetProperty("Detail")!.GetValue(holder);
+            detail.Should().NotBeNull();
+            detailType.GetProperty("Name")!.GetValue(detail).Should().NotBeNull();
         }
 
         [Fact]
-        public void CreateRetainsConstructorAssignedMemberByDefault()
+        public void CreateRetainsConstructorAssignedMemberWhenEnabled()
         {
             const string source = @"
 using ModelBuilder;
@@ -735,7 +779,7 @@ namespace Sample
 
     public static class Caller
     {
-        public static Owner Build() => global::ModelBuilder.Model.Create<Owner>();
+        public static Owner Build() => global::ModelBuilder.Model.SetOptions(o => o.RetainAssignedValues = true).Create<Owner>();
     }
 }";
 
@@ -747,8 +791,8 @@ namespace Sample
             var dogType = assembly.GetType("Sample.Dog", throwOnError: true)!;
             var owner = InvokeCaller(assembly);
 
-            // The more derived instance assigned by the constructor is retained rather than replaced
-            // with a generated value of the less derived member type.
+            // With the option on, the more derived instance assigned by the constructor is retained
+            // rather than replaced with a generated value of the less derived member type.
             ownerType.GetProperty("Pet")!.GetValue(owner).Should().BeOfType(dogType);
         }
 

--- a/ModelBuilder.Generator.UnitTests/GeneratedConstructionExecutionTests.cs
+++ b/ModelBuilder.Generator.UnitTests/GeneratedConstructionExecutionTests.cs
@@ -178,7 +178,7 @@ namespace Sample
             // firstName and lastName are constructor parameters only - never exposed as properties.
         }
 
-        public string Email { get; set; } = string.Empty;
+        public string? Email { get; set; }
     }
 
     public static class Caller
@@ -214,7 +214,7 @@ namespace Sample
         {
         }
 
-        public string Email { get; set; } = string.Empty;
+        public string? Email { get; set; }
     }
 
     public static class Caller
@@ -632,6 +632,150 @@ namespace Sample
 
             var assembly = harness.EmitAndLoad();
             InvokeCaller(assembly).Should().NotBeNull();
+        }
+
+        [Fact]
+        public void PopulateRetainsAssignedMemberValueByDefault()
+        {
+            const string source = @"
+using ModelBuilder;
+
+namespace Sample
+{
+    public sealed class Holder
+    {
+        public string Preset { get; set; } = ""kept"";
+
+        public string? Generated { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Holder Build()
+        {
+            var instance = new Holder();
+
+            return global::ModelBuilder.Model.Populate(instance);
+        }
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
+            var holder = InvokeCaller(assembly);
+
+            // The pre-assigned member is retained while the default member is still generated.
+            holderType.GetProperty("Preset")!.GetValue(holder).Should().Be("kept");
+            holderType.GetProperty("Generated")!.GetValue(holder).Should().NotBeNull();
+        }
+
+        [Fact]
+        public void PopulateOverwritesAssignedMemberWhenRetainDisabled()
+        {
+            const string source = @"
+using ModelBuilder;
+
+namespace Sample
+{
+    public sealed class Holder
+    {
+        public string Preset { get; set; } = ""kept"";
+    }
+
+    public static class Caller
+    {
+        public static Holder Build()
+        {
+            var instance = new Holder();
+
+            return global::ModelBuilder.Model.SetOptions(o => o.RetainAssignedValues = false).Populate(instance);
+        }
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
+            var holder = InvokeCaller(assembly);
+
+            // With retention disabled the pre-assigned value is overwritten with a generated value.
+            holderType.GetProperty("Preset")!.GetValue(holder).Should().NotBe("kept");
+        }
+
+        [Fact]
+        public void CreateRetainsConstructorAssignedMemberByDefault()
+        {
+            const string source = @"
+using ModelBuilder;
+
+namespace Sample
+{
+    public class Animal
+    {
+    }
+
+    public sealed class Dog : Animal
+    {
+    }
+
+    public sealed class Owner
+    {
+        public Owner()
+        {
+            Pet = new Dog();
+        }
+
+        public Animal Pet { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Owner Build() => global::ModelBuilder.Model.Create<Owner>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var ownerType = assembly.GetType("Sample.Owner", throwOnError: true)!;
+            var dogType = assembly.GetType("Sample.Dog", throwOnError: true)!;
+            var owner = InvokeCaller(assembly);
+
+            // The more derived instance assigned by the constructor is retained rather than replaced
+            // with a generated value of the less derived member type.
+            ownerType.GetProperty("Pet")!.GetValue(owner).Should().BeOfType(dogType);
+        }
+
+        [Fact]
+        public void PopulateGuardsMemberAssignmentWithRetainOption()
+        {
+            const string source = @"
+using ModelBuilder;
+
+namespace Sample
+{
+    public sealed class Item
+    {
+        public string? Name { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Item Build() => global::ModelBuilder.Model.Create<Item>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            // The generated assignment is guarded by the runtime retain option.
+            harness.GeneratedSources[0].Should().Contain("context.RetainAssignedValues == false");
         }
 
         private static object InvokeCaller(Assembly assembly)

--- a/ModelBuilder.Generator/SourceEmitter.cs
+++ b/ModelBuilder.Generator/SourceEmitter.cs
@@ -283,7 +283,10 @@ namespace ModelBuilder.Generator
             {
                 builder.Append(Indent).AppendLine($"            if (context.ShouldPopulate(typeof({type}), \"{member.Name}\", typeof({member.TypeName})))");
                 builder.Append(Indent).AppendLine("            {");
-                builder.Append(Indent).AppendLine($"                instance.{member.Name} = context.Build<{member.TypeName}>(typeof({type}), \"{member.Name}\");");
+                builder.Append(Indent).AppendLine($"                if (context.RetainAssignedValues == false || global::System.Collections.Generic.EqualityComparer<{member.TypeName}>.Default.Equals(instance.{member.Name}!, default({member.TypeName})!))");
+                builder.Append(Indent).AppendLine("                {");
+                builder.Append(Indent).AppendLine($"                    instance.{member.Name} = context.Build<{member.TypeName}>(typeof({type}), \"{member.Name}\");");
+                builder.Append(Indent).AppendLine("                }");
                 builder.Append(Indent).AppendLine($"                context.RecordSibling(\"{member.Name}\", instance.{member.Name});");
                 builder.Append(Indent).AppendLine("            }");
             }
@@ -325,7 +328,10 @@ namespace ModelBuilder.Generator
 
                 builder.Append(indent).AppendLine($"if (context.ShouldPopulate(typeof({type}), \"{member.Name}\", typeof({member.TypeName})))");
                 builder.Append(indent).AppendLine("{");
-                builder.Append(indent).Append(Indent).AppendLine($"instance.{member.Name} = context.Build<{member.TypeName}>(typeof({type}), \"{member.Name}\");");
+                builder.Append(indent).Append(Indent).AppendLine($"if (context.RetainAssignedValues == false || global::System.Collections.Generic.EqualityComparer<{member.TypeName}>.Default.Equals(instance.{member.Name}!, default({member.TypeName})!))");
+                builder.Append(indent).Append(Indent).AppendLine("{");
+                builder.Append(indent).Append(Indent).Append(Indent).AppendLine($"instance.{member.Name} = context.Build<{member.TypeName}>(typeof({type}), \"{member.Name}\");");
+                builder.Append(indent).Append(Indent).AppendLine("}");
                 builder.Append(indent).Append(Indent).AppendLine($"context.RecordSibling(\"{member.Name}\", instance.{member.Name});");
                 builder.Append(indent).AppendLine("}");
             }

--- a/ModelBuilder.UnitTests/BuildContextTests.cs
+++ b/ModelBuilder.UnitTests/BuildContextTests.cs
@@ -40,11 +40,11 @@
         }
 
         [Fact]
-        public void RetainAssignedValuesDefaultsToTrue()
+        public void RetainAssignedValuesDefaultsToFalse()
         {
             var sut = new BuildContext(new RandomSource(1));
 
-            sut.RetainAssignedValues.Should().BeTrue();
+            sut.RetainAssignedValues.Should().BeFalse();
         }
 
         [Theory]

--- a/ModelBuilder.UnitTests/BuildContextTests.cs
+++ b/ModelBuilder.UnitTests/BuildContextTests.cs
@@ -40,6 +40,28 @@
         }
 
         [Fact]
+        public void RetainAssignedValuesDefaultsToTrue()
+        {
+            var sut = new BuildContext(new RandomSource(1));
+
+            sut.RetainAssignedValues.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void RetainAssignedValuesReflectsOptions(bool retainAssignedValues)
+        {
+            var options = new BuildOptions
+            {
+                RetainAssignedValues = retainAssignedValues
+            };
+            var sut = new BuildContext(new RandomSource(1), null, options);
+
+            sut.RetainAssignedValues.Should().Be(retainAssignedValues);
+        }
+
+        [Fact]
         public void CreateBuildExceptionCapturesCurrentTargetAndPath()
         {
             var sut = new BuildContext(new RandomSource(1));

--- a/ModelBuilder/BuildContext.cs
+++ b/ModelBuilder/BuildContext.cs
@@ -46,6 +46,7 @@ namespace ModelBuilder
             MinCount = resolvedOptions.MinCount;
             MaxCount = resolvedOptions.MaxCount;
             UseConstructorDefaults = resolvedOptions.UseConstructorDefaults;
+            RetainAssignedValues = resolvedOptions.RetainAssignedValues;
             Configuration = configuration ?? _emptyConfiguration;
             _buildConfiguration = Configuration as BuildConfiguration;
             ValueSources = valueSources ?? BuiltInValueSources.Default;
@@ -495,6 +496,9 @@ namespace ModelBuilder
 
         /// <inheritdoc />
         public bool UseConstructorDefaults { get; }
+
+        /// <inheritdoc />
+        public bool RetainAssignedValues { get; }
 
         /// <summary>
         ///     Gets the maximum depth the build may descend before it is considered to have exceeded a

--- a/ModelBuilder/BuildOptions.cs
+++ b/ModelBuilder/BuildOptions.cs
@@ -90,13 +90,16 @@ namespace ModelBuilder
         ///     otherwise, <c>false</c> and every settable member is overwritten with a generated value.
         /// </returns>
         /// <remarks>
-        ///     This is <c>true</c> by default so that a value already assigned by a constructor or a
-        ///     property initializer is preserved, which also keeps a more derived instance assigned to a
-        ///     less derived member. A member is considered to hold a non-default value when it differs
-        ///     from <c>default</c> for its type, so a reference member that is <c>null</c> and a value
-        ///     member that equals its zero value are always generated and cannot be distinguished from an
-        ///     unset member.
+        ///     This is <c>false</c> by default so that every settable member is populated with a
+        ///     generated value, including a member a constructor or property initializer assigned. This
+        ///     keeps the common case of a property initialised with a newly constructed instance (for
+        ///     example <c>public Address Address { get; set; } = new();</c>) from being left with its own
+        ///     members unpopulated. Set it to <c>true</c> to preserve assigned values, which also keeps a
+        ///     more derived instance assigned to a less derived member. A member is considered to hold a
+        ///     non-default value when it differs from <c>default</c> for its type, so a reference member
+        ///     that is <c>null</c> and a value member that equals its zero value are always generated and
+        ///     cannot be distinguished from an unset member.
         /// </remarks>
-        public bool RetainAssignedValues { get; set; } = true;
+        public bool RetainAssignedValues { get; set; }
     }
 }

--- a/ModelBuilder/BuildOptions.cs
+++ b/ModelBuilder/BuildOptions.cs
@@ -80,5 +80,23 @@ namespace ModelBuilder
         ///     optional parameter's default.
         /// </remarks>
         public bool UseConstructorDefaults { get; set; }
+
+        /// <summary>
+        ///     Gets or sets a value indicating whether a settable member that already holds a non-default
+        ///     value is retained instead of being overwritten with a generated value.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if a member that already holds a non-default value is left untouched;
+        ///     otherwise, <c>false</c> and every settable member is overwritten with a generated value.
+        /// </returns>
+        /// <remarks>
+        ///     This is <c>true</c> by default so that a value already assigned by a constructor or a
+        ///     property initializer is preserved, which also keeps a more derived instance assigned to a
+        ///     less derived member. A member is considered to hold a non-default value when it differs
+        ///     from <c>default</c> for its type, so a reference member that is <c>null</c> and a value
+        ///     member that equals its zero value are always generated and cannot be distinguished from an
+        ///     unset member.
+        /// </remarks>
+        public bool RetainAssignedValues { get; set; } = true;
     }
 }

--- a/ModelBuilder/IBuildContext.cs
+++ b/ModelBuilder/IBuildContext.cs
@@ -37,6 +37,16 @@ namespace ModelBuilder
         bool UseConstructorDefaults { get; }
 
         /// <summary>
+        ///     Gets a value indicating whether a settable member that already holds a non-default value
+        ///     is retained instead of being overwritten with a generated value.
+        /// </summary>
+        /// <returns>
+        ///     <c>true</c> if a member that already holds a non-default value is left untouched;
+        ///     otherwise, <c>false</c>.
+        /// </returns>
+        bool RetainAssignedValues { get; }
+
+        /// <summary>
         ///     Builds a value for a member, resolving a registered value source first and then a
         ///     registered builder, with circular-reference and depth guards applied for built types.
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ member as a string:
 var request = Model.Ignoring(typeof(Request), nameof(Request.Data)).Create<Request>();
 ```
 
+The type is matched by assignability, so a rule declared on a base class or an interface also applies
+to the same-named member on any derived or implementing type. For example,
+`Ignoring(typeof(Stream), nameof(Stream.CanRead))` ignores `CanRead` wherever a `MemoryStream` (or any
+other `Stream`) appears in the graph, and a rule on an interface covers every type that implements it.
+Declare the rule on the exact type to scope it to that type alone.
+
 `IgnoringAny(Func<MemberSignature, bool> predicate)` ignores every member, on any type, for which the
 predicate returns `true`. The predicate receives a `MemberSignature` exposing the member's
 `DeclaringType`, `Name` and `MemberType`, so you can match by naming convention, declaring type or
@@ -632,7 +638,7 @@ override — starts from these defaults. A module, or a fluent call on `Model`, 
 | Custom value sources | None registered, but the **built-in value sources always apply** (you never register them, and a custom source only overrides the built-in for its type/name). |
 | Built-in typed sources | `bool`; every numeric type (`byte`/`sbyte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double`/`decimal`); `char`; `string`; `Guid`; `DateTime`; `DateTimeOffset`; `TimeSpan`; `Uri`; `Version`; `byte[]`. Enums, nullables and collections are handled by the generator. |
 | Built-in named sources | The entity-style member-name sources in [Built-in data](#entity-style-data-matched-by-member-name) (names, email, company, location fields, age, date of birth, …). |
-| Build options | `MinCount` 1, `MaxCount` 10, `NullPercentage` 5, `MaxDepth` 50, `UseConstructorDefaults` off — see [Tuning the build](#tuning-the-build). |
+| Build options | `MinCount` 1, `MaxCount` 10, `NullPercentage` 5, `MaxDepth` 50, `UseConstructorDefaults` off, `RetainAssignedValues` on — see [Tuning the build](#tuning-the-build). |
 
 ## Tuning the build
 
@@ -682,6 +688,31 @@ This applies only to the constructor `Create<T>()` selects. The explicit
 [`Construct<T>().From(...)`](#typed-construction) path always gives per-argument control regardless of
 this option, because its generated overloads expose each optional parameter's default.
 
+`RetainAssignedValues` (on by default) controls whether a settable member that already holds a
+non-default value is kept instead of being overwritten with a generated value. With it on, a value a
+constructor or a property initializer assigned is preserved, which also keeps a more derived instance
+assigned to a less derived member:
+
+```csharp
+public sealed class Owner
+{
+    public Owner() => Pet = new Dog();   // Dog : Animal
+
+    public Animal Pet { get; set; }
+}
+
+// Pet keeps the Dog the constructor assigned rather than being replaced with a generated Animal.
+var owner = Model.Create<Owner>();
+
+// Turn the option off to overwrite every settable member with a generated value.
+var replaced = Model.SetOptions(x => x.RetainAssignedValues = false).Create<Owner>();
+```
+
+A member counts as assigned only when it differs from `default` for its type, so a `null` reference
+member or a value member equal to its zero value is always generated and cannot be distinguished from
+an unset one. This runtime check is separate from constructor-parameter matching, which already
+excludes matched members from the generated population code at compile time.
+
 ## Built-in data
 
 ModelBuilder ships value sources for the common primitive and BCL types (`bool`, the numeric types,
@@ -705,7 +736,7 @@ is *not* treated as an `Age`.
 | `Email` | `first.last@domain` |
 | `Domain` | A domain |
 | `Company`, `Business` | A company name |
-| `Country` | A country |
+| `Country`, `Region`, `CountryRegion` | A country |
 | `State`, `Province` | A state or province |
 | `City`, `Suburb`, `Town` | A city |
 | `PostCode`, `ZipCode`, `Postcode`, `Zip` | A post/zip code |

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ override — starts from these defaults. A module, or a fluent call on `Model`, 
 | Custom value sources | None registered, but the **built-in value sources always apply** (you never register them, and a custom source only overrides the built-in for its type/name). |
 | Built-in typed sources | `bool`; every numeric type (`byte`/`sbyte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double`/`decimal`); `char`; `string`; `Guid`; `DateTime`; `DateTimeOffset`; `TimeSpan`; `Uri`; `Version`; `byte[]`. Enums, nullables and collections are handled by the generator. |
 | Built-in named sources | The entity-style member-name sources in [Built-in data](#entity-style-data-matched-by-member-name) (names, email, company, location fields, age, date of birth, …). |
-| Build options | `MinCount` 1, `MaxCount` 10, `NullPercentage` 5, `MaxDepth` 50, `UseConstructorDefaults` off, `RetainAssignedValues` on — see [Tuning the build](#tuning-the-build). |
+| Build options | `MinCount` 1, `MaxCount` 10, `NullPercentage` 5, `MaxDepth` 50, `UseConstructorDefaults` off, `RetainAssignedValues` off — see [Tuning the build](#tuning-the-build). |
 
 ## Tuning the build
 
@@ -688,10 +688,12 @@ This applies only to the constructor `Create<T>()` selects. The explicit
 [`Construct<T>().From(...)`](#typed-construction) path always gives per-argument control regardless of
 this option, because its generated overloads expose each optional parameter's default.
 
-`RetainAssignedValues` (on by default) controls whether a settable member that already holds a
-non-default value is kept instead of being overwritten with a generated value. With it on, a value a
-constructor or a property initializer assigned is preserved, which also keeps a more derived instance
-assigned to a less derived member:
+`RetainAssignedValues` (off by default) controls whether a settable member that already holds a
+non-default value is kept instead of being overwritten with a generated value. Off, every settable
+member is populated with a generated value, including one a constructor or property initializer
+assigned — so a property newed up with an empty instance (`public Address Address { get; set; } = new();`)
+still has its own members filled in. Turn it on to preserve assigned values, which also keeps a more
+derived instance assigned to a less derived member:
 
 ```csharp
 public sealed class Owner
@@ -701,11 +703,9 @@ public sealed class Owner
     public Animal Pet { get; set; }
 }
 
-// Pet keeps the Dog the constructor assigned rather than being replaced with a generated Animal.
-var owner = Model.Create<Owner>();
-
-// Turn the option off to overwrite every settable member with a generated value.
-var replaced = Model.SetOptions(x => x.RetainAssignedValues = false).Create<Owner>();
+// With the option on, Pet keeps the Dog the constructor assigned rather than being replaced with a
+// generated Animal. Off (the default), Pet is rebuilt as a generated Animal.
+var owner = Model.SetOptions(x => x.RetainAssignedValues = true).Create<Owner>();
 ```
 
 A member counts as assigned only when it differs from `default` for its type, so a `null` reference


### PR DESCRIPTION
Implements #145.

## Behaviour
Adds `BuildOptions.RetainAssignedValues` (default **false**, opt-in). When enabled, a settable member that already holds a non-default value (assigned by a constructor or property initializer) is retained instead of being overwritten with a generated value. This preserves a more derived instance assigned to a less derived member, which is the scenario in #145.

The default is **false** so the previous behaviour is unchanged: every settable member is populated, including one newed up with an empty instance (e.g. `public Address Address { get; set; } = new();`) - otherwise such an instance would be retained with all of its own members left unset. Set `RetainAssignedValues = true` to opt in.

A member counts as assigned only when it differs from `default` for its type, so a `null` reference member or a value member equal to its zero value is always generated. This runtime check is separate from constructor-parameter matching, which already excludes matched members from the generated code at compile time.

## Changes
- `BuildOptions.RetainAssignedValues` + `IBuildContext.RetainAssignedValues` (flowed through `BuildContext`).
- Generated `Populate`/`Create` member assignment guarded by the option and a `EqualityComparer<T>.Default.Equals(member, default)` check.
- Tests: opt-in retain and default overwrite for both `Populate` and `Create` (incl. derived-instance retention and the newed-up-instance case), generated-output guard, and `BuildContext` option-flow.
- README: documented in Tuning the build and the default-configuration table.
- Also documents the #146 (ignore-by-assignability) and #345 (Region/CountryRegion aliases) features that shipped without docs.

## Folded-in dependency updates
Bumps GitHub Actions, superseding Dependabot PRs #382/#381/#380: `checkout` 5->7, `upload-artifact` 6->7, `download-artifact` 7->8.

## Validation
`dotnet build` clean (0/0). Suites pass: 330 unit, 121 generator, 2 code-fix.

`+semver: minor` - additive opt-in option, no behaviour change to existing callers.