### PR TITLE
Publish pre-release packages from main branch builds (#379)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,10 @@ jobs:
     # softprops/action-gh-release creates a GitHub release, which needs write access to repo contents.
     permissions:
       contents: write
-    # Only run on pushes which should only be on the base repository and only where the branch is master or is a version tagged build
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'dependabot[bot]'
+    # Run on pushes to the base repository for the default branch (main) or a version tagged build.
+    # Main builds are untagged and GitVersion stamps them as a beta pre-release (see GitVersion.yml),
+    # so they publish pre-release packages; version tags publish the stable release.
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'dependabot[bot]'
 
     steps:
     
@@ -190,6 +192,9 @@ jobs:
       run: dotnet nuget push "*.symbols.nupkg" --api-key "$NUGET_APIKEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Create release and upload assets
+      # Only create a GitHub release for an explicit version tag; main pre-release builds publish the
+      # NuGet packages above but must not create a GitHub release (and tag) on every commit.
+      if: startsWith(github.ref, 'refs/tags/v')
       uses: softprops/action-gh-release@v3
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Implements #379.

## Problem
The `release` job only publishes to NuGet.org / GitHub Packages, but its condition gated on `github.ref == 'refs/heads/master'`. The default branch is `main`, so untagged main builds never ran the job and were never published. Only `v*` tag pushes reached NuGet.org.

## Fix
- Point the `release` job condition at `refs/heads/main` (the default branch) so main pushes run it. GitVersion stamps main as a `beta` pre-release (`mode: ContinuousDelivery` in GitVersion.yml), e.g. `9.1.0-beta.N`, which NuGet.org accepts as a pre-release package.
- Gate the `Create release and upload assets` step to `startsWith(github.ref, 'refs/tags/v')` so a GitHub release (and tag) is only created for explicit version tags, not on every main commit. Main commits still publish the pre-release packages to GitHub Packages and NuGet.org.

## Result
- Main push (untagged): publishes `9.x.y-beta.N` pre-release to MyGet (unchanged), GitHub Packages and NuGet.org. No GitHub release created.
- `v*` tag push: unchanged - publishes the stable release everywhere and creates the GitHub release.

## Validation
Workflow-only change; YAML validated with a parser. `--skip-duplicate` already guards re-pushes.