### PR TITLE
Authenticate GitHub Packages push with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,9 +146,11 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    # softprops/action-gh-release creates a GitHub release, which needs write access to repo contents.
+    # action-gh-release needs contents: write to create the GitHub release; the GitHub Packages push
+    # below authenticates with the built-in GITHUB_TOKEN, which needs packages: write.
     permissions:
       contents: write
+      packages: write
     # Run on pushes to the base repository for the default branch (main) or a version tagged build.
     # Main builds are untagged and GitVersion stamps them as a beta pre-release (see GitVersion.yml),
     # so they publish pre-release packages; version tags publish the stable release.
@@ -182,8 +184,10 @@ jobs:
         dotnet-version: 10.x
       
     - name: Publish to GitHub
+      # Authenticate with the workflow's built-in GITHUB_TOKEN (scoped by packages: write above) rather
+      # than a personal access token secret, so publishing does not break when a PAT expires.
       env: 
-        GPR_APIKEY: ${{ secrets.GPR_APIKEY }}
+        GPR_APIKEY: ${{ secrets.GITHUB_TOKEN }}
       run: dotnet nuget push "*.symbols.nupkg" --api-key "$GPR_APIKEY" --source https://nuget.pkg.github.com/roryprimrose/index.json --skip-duplicate
       
     - name: Publish to NuGet.org


### PR DESCRIPTION
Fixes the main-branch CI failure from #379 ([run 28273970817](https://github.com/roryprimrose/ModelBuilder/actions/runs/28273970817)).

## Problem
Now that the `release` job runs on main (per #379), its **Publish to GitHub** step failed:

```\nwarn : Your request could not be authenticated by the GitHub Packages service.\n  Unauthorized https://nuget.pkg.github.com/roryprimrose/\nerror: Response status code does not indicate success: 401 (Unauthorized).\n```\n
The `GPR_APIKEY` PAT secret is invalid/expired. Because that step runs **before** `Publish to NuGet.org` with no `continue-on-error`, the job aborts and the main pre-release package never reaches NuGet.org - defeating #379.

## Fix
- Authenticate the GitHub Packages push with the workflow's built-in `GITHUB_TOKEN` instead of the `GPR_APIKEY` PAT, so it no longer depends on a maintainer-renewed token.
- Add `packages: write` to the `release` job permissions (required for `GITHUB_TOKEN` to push packages).

## Validation
Workflow-only change; YAML validated with a parser. `--skip-duplicate` still guards re-pushes.