### PR TITLE
Harden GitHub security settings

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported versions
+
+Security fixes are provided for the most recently released version of
+ModelBuilder published on [NuGet](https://www.nuget.org/packages/ModelBuilder).
+Please upgrade to the latest release before reporting a vulnerability.
+
+## Reporting a vulnerability
+
+Please do **not** report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.
+
+Instead, report them privately using GitHub's
+[private vulnerability reporting](https://github.com/roryprimrose/ModelBuilder/security/advisories/new).
+This opens a confidential advisory that only the maintainers can see.
+
+When reporting, please include as much of the following as you can:
+
+- The affected version(s) and target framework.
+- A description of the vulnerability and its impact.
+- Steps to reproduce, ideally a minimal reproducer or failing test.
+- Any known workarounds.
+
+## What to expect
+
+This is a community-maintained open source project without a dedicated 24/7
+response team, so please allow a reasonable amount of time for an initial
+response. We will acknowledge your report, work with you to understand and
+validate the issue, and coordinate the disclosure timeline with you once a fix
+is available.

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+# Reviews dependency changes on pull requests and fails the build if a pull
+# request introduces a dependency with a known vulnerability. Requires the
+# repository's Dependency Graph to be enabled (on by default for public repos).
+on:
+  pull_request:
+    branches:
+      - '**'
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
Hardens the repository's security configuration in line with GitHub's `6 security settings every maintainer should enable`:

- Adds `.github/SECURITY.md` directing reporters to private vulnerability reporting.
- Adds `.github/workflows/dependency-review.yml` to block PRs that introduce high-severity vulnerable dependencies.

Secret scanning + push protection, private vulnerability reporting, and CodeQL default setup were also enabled at the repository level.