### PR TITLE
v9: Support collection root types, members, and custom collection subclasses (#397)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,14 @@ jobs:
     - name: Install coverage tool
       run: dotnet tool install --global dotnet-coverage --version 18.8.0
 
+    - name: Install Mono
+      # ModelBuilder.IntegrationTests (and ModelBuilder.BenchmarkTests) target net472 to exercise the
+      # netstandard2.0 consumption path. The net472 test host needs Mono to execute on this Linux
+      # runner, which isn't preinstalled.
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y mono-complete
+
     - name: Test
       # dotnet-coverage wraps the test run and instruments the test host processes, writing one merged
       # Cobertura report. This is decoupled from the Microsoft.Testing.Platform version that xUnit v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     # the value always matches the packaged version.
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         # 10.x provides the SDK pinned in global.json; 8.x provides the runtime the tests target.
         dotnet-version: |
@@ -142,7 +142,7 @@ jobs:
         name: packages
       
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.x
 
@@ -187,7 +187,7 @@ jobs:
       run: Add-Content -Path ${env:GITHUB_ENV} "`nprojectName=$(${env:GITHUB_REPOSITORY}.substring(${env:GITHUB_REPOSITORY}.IndexOf('/') + 1))" -Encoding utf8
       
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@v6
       with:
         dotnet-version: 10.x
       

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -19,6 +19,6 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,8 +12,8 @@
 
   <!-- Source generator (Roslyn) -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
   </ItemGroup>
 
   <!-- Versioning. Referenced CI-only from Directory.Build.props; matches the GitVersion 6.8.2 config. -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,19 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
   </ItemGroup>
 
-  <!-- Source generator (Roslyn) -->
+  <!--
+    Source generator (Roslyn).
+    KNOWN INCOMPATIBILITY (2026-07-23): bumping to 5.6.0 (Dependabot PR #393) built and passed the
+    full test suite locally on Windows, but crashed the "Test" step in CI (ubuntu-latest) with exit
+    code 134 (SIGABRT) in ~12s — far faster than a normal test run, indicating a runtime/native
+    crash rather than a test failure. Reverting only this pin back to 4.14.0 (keeping every other
+    dependency bump from that same PR batch) fixed CI immediately, isolating the crash to this
+    package's major version jump. Root cause not fully diagnosed (GitHub Actions log content wasn't
+    retrievable with available tooling), but it reproduces reliably on Linux CI and not on Windows,
+    so a local build/test pass is NOT sufficient to validate a future bump here.
+    Before bumping past 4.x again: bump on a branch, push, and confirm the CI "build" job (not just
+    a local run) is green before merging.
+  -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,18 +7,18 @@
 
   <!-- Production analyzers -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.301" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="10.0.302" />
   </ItemGroup>
 
   <!-- Source generator (Roslyn) -->
   <ItemGroup>
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.6.0" />
   </ItemGroup>
 
-  <!-- Versioning. Referenced CI-only from Directory.Build.props; matches the GitVersion 6.7.0 config. -->
+  <!-- Versioning. Referenced CI-only from Directory.Build.props; matches the GitVersion 6.8.2 config. -->
   <ItemGroup>
-    <PackageVersion Include="GitVersion.MsBuild" Version="6.7.0" />
+    <PackageVersion Include="GitVersion.MsBuild" Version="6.8.2" />
   </ItemGroup>
 
   <!-- Benchmarking -->

--- a/ModelBuilder.Generator.UnitTests/GeneratedExecutionTests.cs
+++ b/ModelBuilder.Generator.UnitTests/GeneratedExecutionTests.cs
@@ -641,6 +641,165 @@ namespace Sample
         }
 
         [Fact]
+        public void CreateBuildsCustomTypeThatInheritsCollection()
+        {
+            const string source = @"
+namespace Sample
+{
+    public sealed class WidgetBag : System.Collections.ObjectModel.Collection<int>
+    {
+    }
+
+    public sealed class Holder
+    {
+        public WidgetBag? Bag { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Holder Build() => global::ModelBuilder.Model.Create<Holder>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
+
+            ValueSource<int>.Instance = new SequentialInt32Source();
+
+            try
+            {
+                var holder = CreateViaModel(holderType);
+
+                var bag = holderType.GetProperty("Bag")!.GetValue(holder);
+
+                bag.Should().NotBeNull();
+                bag.Should().BeOfType(assembly.GetType("Sample.WidgetBag", throwOnError: true)!);
+
+                var enumerable = (System.Collections.IEnumerable)bag!;
+
+                enumerable.Cast<object>().Should().NotBeEmpty();
+            }
+            finally
+            {
+                ValueSource<int>.Instance = null;
+            }
+        }
+
+        [Fact]
+        public void CreateBuildsCustomTypeThatInheritsDictionary()
+        {
+            const string source = @"
+namespace Sample
+{
+    public sealed class WidgetMap : System.Collections.Generic.Dictionary<int, int>
+    {
+    }
+
+    public sealed class Holder
+    {
+        public WidgetMap? Map { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Holder Build() => global::ModelBuilder.Model.Create<Holder>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
+
+            ValueSource<int>.Instance = new SequentialInt32Source();
+
+            try
+            {
+                var holder = CreateViaModel(holderType);
+
+                var map = holderType.GetProperty("Map")!.GetValue(holder);
+
+                map.Should().NotBeNull();
+                map.Should().BeOfType(assembly.GetType("Sample.WidgetMap", throwOnError: true)!);
+
+                var dictionary = (System.Collections.IDictionary)map!;
+
+                dictionary.Count.Should().BeGreaterThan(0);
+            }
+            finally
+            {
+                ValueSource<int>.Instance = null;
+            }
+        }
+
+        [Fact]
+        public void CreateBuildsCustomTypeThatImplementsIList()
+        {
+            const string source = @"
+namespace Sample
+{
+    public sealed class CustomList : System.Collections.Generic.IList<int>
+    {
+        private readonly System.Collections.Generic.List<int> _items = new System.Collections.Generic.List<int>();
+
+        public int this[int index] { get => _items[index]; set => _items[index] = value; }
+        public int Count => _items.Count;
+        public bool IsReadOnly => false;
+        public void Add(int item) => _items.Add(item);
+        public void Clear() => _items.Clear();
+        public bool Contains(int item) => _items.Contains(item);
+        public void CopyTo(int[] array, int arrayIndex) => _items.CopyTo(array, arrayIndex);
+        public System.Collections.Generic.IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+        public int IndexOf(int item) => _items.IndexOf(item);
+        public void Insert(int index, int item) => _items.Insert(index, item);
+        public bool Remove(int item) => _items.Remove(item);
+        public void RemoveAt(int index) => _items.RemoveAt(index);
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => _items.GetEnumerator();
+    }
+
+    public sealed class Holder
+    {
+        public CustomList? Items { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Holder Build() => global::ModelBuilder.Model.Create<Holder>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
+
+            ValueSource<int>.Instance = new SequentialInt32Source();
+
+            try
+            {
+                var holder = CreateViaModel(holderType);
+
+                var items = holderType.GetProperty("Items")!.GetValue(holder);
+
+                items.Should().NotBeNull();
+                items.Should().BeOfType(assembly.GetType("Sample.CustomList", throwOnError: true)!);
+
+                var enumerable = (System.Collections.IEnumerable)items!;
+
+                enumerable.Cast<object>().Should().NotBeEmpty();
+            }
+            finally
+            {
+                ValueSource<int>.Instance = null;
+            }
+        }
+
+        [Fact]
         public void UnsupportedCollectionShapeReportsDiagnostic()
         {
             const string source = @"

--- a/ModelBuilder.Generator.UnitTests/GeneratedExecutionTests.cs
+++ b/ModelBuilder.Generator.UnitTests/GeneratedExecutionTests.cs
@@ -524,6 +524,145 @@ namespace Sample
         }
 
         [Fact]
+        public void CreateBuildsExpandedCollectionKinds()
+        {
+            const string source = @"
+namespace Sample
+{
+    public sealed class Bag
+    {
+        public System.Collections.Generic.Queue<int> Queue { get; set; }
+        public System.Collections.Generic.Stack<int> Stack { get; set; }
+        public System.Collections.Generic.SortedSet<int> SortedSet { get; set; }
+        public System.Collections.ObjectModel.Collection<int> Collection { get; set; }
+        public System.Collections.ObjectModel.ObservableCollection<int> Observable { get; set; }
+        public System.Collections.Concurrent.ConcurrentBag<int> ConcurrentBag { get; set; }
+        public System.Collections.Concurrent.ConcurrentQueue<int> ConcurrentQueue { get; set; }
+        public System.Collections.Concurrent.ConcurrentStack<int> ConcurrentStack { get; set; }
+        public System.Collections.Generic.SortedDictionary<int, int> SortedDictionary { get; set; }
+        public System.Collections.Generic.SortedList<int, int> SortedList { get; set; }
+        public System.Collections.Concurrent.ConcurrentDictionary<int, int> ConcurrentDictionary { get; set; }
+        public System.Collections.ObjectModel.ReadOnlyCollection<int> ReadOnlyCollection { get; set; }
+        public System.Collections.ObjectModel.ReadOnlyDictionary<int, int> ReadOnlyDictionary { get; set; }
+        public System.Collections.ObjectModel.ReadOnlyObservableCollection<int> ReadOnlyObservable { get; set; }
+        public System.Collections.Immutable.ImmutableArray<int> ImmutableArray { get; set; }
+        public System.Collections.Immutable.ImmutableList<int> ImmutableList { get; set; }
+        public System.Collections.Immutable.ImmutableHashSet<int> ImmutableHashSet { get; set; }
+        public System.Collections.Immutable.ImmutableSortedSet<int> ImmutableSortedSet { get; set; }
+        public System.Collections.Immutable.ImmutableDictionary<int, int> ImmutableDictionary { get; set; }
+        public System.Collections.Immutable.ImmutableSortedDictionary<int, int> ImmutableSortedDictionary { get; set; }
+        public System.Collections.Immutable.ImmutableQueue<int> ImmutableQueue { get; set; }
+        public System.Collections.Immutable.ImmutableStack<int> ImmutableStack { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Bag Build() => global::ModelBuilder.Model.Create<Bag>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var bagType = assembly.GetType("Sample.Bag", throwOnError: true)!;
+
+            ValueSource<int>.Instance = new SequentialInt32Source();
+
+            try
+            {
+                var bag = CreateViaModel(bagType);
+
+                foreach (var property in bagType.GetProperties())
+                {
+                    var value = property.GetValue(bag);
+
+                    value.Should().NotBeNull($"{property.Name} should have been populated");
+
+                    var enumerable = (System.Collections.IEnumerable)value!;
+
+                    enumerable.Cast<object>().Should().NotBeEmpty($"{property.Name} should contain items");
+                }
+            }
+            finally
+            {
+                ValueSource<int>.Instance = null;
+            }
+        }
+
+        [Fact]
+        public void CreateByTypeBuildsCollectionOnlyRoot()
+        {
+            const string source = @"
+namespace Sample
+{
+    public static class Caller
+    {
+        public static object Build() => global::ModelBuilder.Model.Create(typeof(System.Collections.Generic.List<int>));
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var callerType = assembly.GetType("Sample.Caller", throwOnError: true)!;
+
+            var result = callerType.GetMethod("Build")!.Invoke(null, null);
+
+            var list = (System.Collections.IEnumerable)result!;
+
+            list.Cast<object>().Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void CreateBuildsGenericCollectionOnlyRoot()
+        {
+            const string source = @"
+namespace Sample
+{
+    public static class Caller
+    {
+        public static System.Collections.Generic.List<int> Build() => global::ModelBuilder.Model.Create<System.Collections.Generic.List<int>>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var callerType = assembly.GetType("Sample.Caller", throwOnError: true)!;
+
+            var result = callerType.GetMethod("Build")!.Invoke(null, null);
+
+            var list = (System.Collections.IEnumerable)result!;
+
+            list.Cast<object>().Should().NotBeEmpty();
+        }
+
+        [Fact]
+        public void UnsupportedCollectionShapeReportsDiagnostic()
+        {
+            const string source = @"
+namespace Sample
+{
+    public sealed class Bag
+    {
+        public System.ArraySegment<int> Segment { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Bag Build() => global::ModelBuilder.Model.Create<Bag>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+
+            harness.GeneratorDiagnostics.Should().Contain(d => d.Id == "MB1011");
+        }
+
+        [Fact]
         public void CreateBuildsStructWithSettableProperties()
         {
             const string source = @"

--- a/ModelBuilder.Generator/AnalyzerReleases.Unshipped.md
+++ b/ModelBuilder.Generator/AnalyzerReleases.Unshipped.md
@@ -8,3 +8,4 @@ Rule ID | Category | Severity | Notes
 MB1001  | ModelBuilder | Warning | Abstract or interface build root has no mapping
 MB1002  | ModelBuilder | Warning | Build root has no accessible constructor
 MB1005  | ModelBuilder | Warning | Model.Create(typeof(X)) names a type that cannot be built
+MB1011  | ModelBuilder | Warning | Discovered collection shape is not supported

--- a/ModelBuilder.Generator/BuildGraphWalker.cs
+++ b/ModelBuilder.Generator/BuildGraphWalker.cs
@@ -152,6 +152,7 @@ namespace ModelBuilder.Generator
 
             var keyCanBeNull = _keyedCollectionKinds.Contains(kind) && element?.IsReferenceType == true;
             var retryOnKeyCollision = _retryOnKeyCollisionKinds.Contains(kind);
+            var isCustomType = IsCustomCollectionType(type);
 
             return new CollectionModel(
                 kind,
@@ -160,7 +161,22 @@ namespace ModelBuilder.Generator
                 element?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty,
                 value?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty,
                 keyCanBeNull,
-                retryOnKeyCollision);
+                retryOnKeyCollision,
+                isCustomType);
+        }
+
+        private static bool IsCustomCollectionType(ITypeSymbol type)
+        {
+            if (type is not INamedTypeSymbol named)
+            {
+                // Arrays are always built as the well-known T[] shape.
+                return false;
+            }
+
+            // A type is "custom" when it reached collection classification without directly
+            // matching one of the well-known BCL definitions/interfaces itself - i.e. it was
+            // classified through inheritance or interface implementation instead.
+            return TryClassifyByDefinition(named.OriginalDefinition.ToDisplayString(), named.TypeArguments, out _, out _, out _) == false;
         }
 
         private static EnumModel CreateEnumModel(INamedTypeSymbol type, string fullyQualifiedName, HashSet<string> sourceNames)
@@ -312,7 +328,7 @@ namespace ModelBuilder.Generator
                 return true;
             }
 
-            if (type is not INamedTypeSymbol { IsGenericType: true } named)
+            if (type is not INamedTypeSymbol named)
             {
                 return false;
             }
@@ -324,8 +340,40 @@ namespace ModelBuilder.Generator
                 return false;
             }
 
-            var definition = named.OriginalDefinition.ToDisplayString();
-            var args = named.TypeArguments;
+            if (named.IsGenericType
+                && TryClassifyByDefinition(named.OriginalDefinition.ToDisplayString(), named.TypeArguments, out kind, out element, out value))
+            {
+                return true;
+            }
+
+            // A user-defined type that derives from a known mutable BCL collection (for example
+            // `class WidgetBag : Collection<Widget>`) or implements `ICollection<T>`/
+            // `IDictionary<TKey, TValue>` directly (for example a hand-written `IList<T>`
+            // implementation) is built the same way as its matched shape, but constructed as the
+            // requested type itself so its own behavior/state is preserved.
+            if (named.TypeKind == TypeKind.Class
+                && named.IsAbstract == false
+                && IsAccessible(named)
+                && HasPublicParameterlessConstructor(named)
+                && (TryClassifyByBaseDefinition(named, out kind, out element, out value)
+                    || TryClassifyByInterfaceImplementation(named, out kind, out element, out value)))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryClassifyByDefinition(
+            string definition,
+            ImmutableArray<ITypeSymbol> args,
+            out CollectionKind kind,
+            out ITypeSymbol? element,
+            out ITypeSymbol? value)
+        {
+            kind = CollectionKind.Array;
+            element = null;
+            value = null;
 
             switch (definition)
             {
@@ -489,6 +537,186 @@ namespace ModelBuilder.Generator
             }
         }
 
+        private static bool TryClassifyByBaseDefinition(
+            INamedTypeSymbol named,
+            out CollectionKind kind,
+            out ITypeSymbol? element,
+            out ITypeSymbol? value)
+        {
+            for (var ancestor = named.BaseType;
+                 ancestor != null && ancestor.SpecialType != SpecialType.System_Object;
+                 ancestor = ancestor.BaseType)
+            {
+                if (ancestor.IsGenericType == false)
+                {
+                    continue;
+                }
+
+                if (TryClassifyByMutableBaseDefinition(ancestor.OriginalDefinition.ToDisplayString(), ancestor.TypeArguments, out kind, out element, out value))
+                {
+                    return true;
+                }
+            }
+
+            kind = CollectionKind.Array;
+            element = null;
+            value = null;
+
+            return false;
+        }
+
+        private static bool TryClassifyByMutableBaseDefinition(
+            string definition,
+            ImmutableArray<ITypeSymbol> args,
+            out CollectionKind kind,
+            out ITypeSymbol? element,
+            out ITypeSymbol? value)
+        {
+            // Only the concrete, non-sealed, parameterless-constructible BCL collection kinds are
+            // classifiable as an inheritance base. Read-only wrappers and immutable kinds are
+            // excluded here: they have no usable parameterless constructor (or, for the immutable
+            // kinds, are sealed and cannot be subclassed at all).
+            kind = CollectionKind.Array;
+            element = null;
+            value = null;
+
+            switch (definition)
+            {
+                case "System.Collections.Generic.List<T>":
+                    kind = CollectionKind.List;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Generic.HashSet<T>":
+                    kind = CollectionKind.Set;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.ObjectModel.Collection<T>":
+                    kind = CollectionKind.Collection;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Generic.Queue<T>":
+                    kind = CollectionKind.Queue;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Generic.Stack<T>":
+                    kind = CollectionKind.Stack;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Generic.SortedSet<T>":
+                    kind = CollectionKind.SortedSet;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.ObjectModel.ObservableCollection<T>":
+                    kind = CollectionKind.ObservableCollection;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Concurrent.ConcurrentBag<T>":
+                    kind = CollectionKind.ConcurrentBag;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Concurrent.ConcurrentQueue<T>":
+                    kind = CollectionKind.ConcurrentQueue;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Concurrent.ConcurrentStack<T>":
+                    kind = CollectionKind.ConcurrentStack;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Generic.Dictionary<TKey, TValue>":
+                    kind = CollectionKind.Dictionary;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
+                case "System.Collections.Generic.SortedDictionary<TKey, TValue>":
+                    kind = CollectionKind.SortedDictionary;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
+                case "System.Collections.Generic.SortedList<TKey, TValue>":
+                    kind = CollectionKind.SortedList;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
+                case "System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>":
+                    kind = CollectionKind.ConcurrentDictionary;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private static bool TryClassifyByInterfaceImplementation(
+            INamedTypeSymbol named,
+            out CollectionKind kind,
+            out ITypeSymbol? element,
+            out ITypeSymbol? value)
+        {
+            // A custom type that implements IDictionary<TKey, TValue> directly (rather than
+            // deriving from a known keyed base type) is keyed - checked first since
+            // IDictionary<TKey, TValue> also implements ICollection<KeyValuePair<TKey, TValue>>.
+            foreach (var candidateInterface in named.AllInterfaces)
+            {
+                if (candidateInterface.IsGenericType
+                    && candidateInterface.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.IDictionary<TKey, TValue>")
+                {
+                    kind = CollectionKind.Dictionary;
+                    element = candidateInterface.TypeArguments[0];
+                    value = candidateInterface.TypeArguments[1];
+
+                    return true;
+                }
+            }
+
+            // A custom type that implements ICollection<T> directly (for example a hand-written
+            // IList<T> implementation, since IList<T> extends ICollection<T>) is Add-based.
+            foreach (var candidateInterface in named.AllInterfaces)
+            {
+                if (candidateInterface.IsGenericType
+                    && candidateInterface.OriginalDefinition.ToDisplayString() == "System.Collections.Generic.ICollection<T>")
+                {
+                    kind = CollectionKind.List;
+                    element = candidateInterface.TypeArguments[0];
+                    value = null;
+
+                    return true;
+                }
+            }
+
+            kind = CollectionKind.Array;
+            element = null;
+            value = null;
+
+            return false;
+        }
+
+        private static bool HasPublicParameterlessConstructor(INamedTypeSymbol type)
+        {
+            foreach (var constructor in type.InstanceConstructors)
+            {
+                if (constructor.DeclaredAccessibility == Accessibility.Public && constructor.Parameters.Length == 0)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         private static BuildableModel CreateModel(
             INamedTypeSymbol type,

--- a/ModelBuilder.Generator/BuildGraphWalker.cs
+++ b/ModelBuilder.Generator/BuildGraphWalker.cs
@@ -25,10 +25,16 @@ namespace ModelBuilder.Generator
 
         public static GenerationModel Walk(IEnumerable<INamedTypeSymbol> roots)
         {
+            return Walk(roots, out _);
+        }
+
+        public static GenerationModel Walk(IEnumerable<INamedTypeSymbol> roots, out ImmutableArray<string> unsupportedCollectionShapes)
+        {
             var discovered = new Dictionary<string, INamedTypeSymbol>();
             var enums = new Dictionary<string, INamedTypeSymbol>();
             var nullables = new SortedSet<string>(System.StringComparer.Ordinal);
             var collections = new Dictionary<string, ITypeSymbol>();
+            var unsupported = new HashSet<string>();
             var queue = new Queue<INamedTypeSymbol>();
             var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 
@@ -44,6 +50,23 @@ namespace ModelBuilder.Generator
                 if (type.TypeKind == TypeKind.Enum)
                 {
                     enums[type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)] = type;
+
+                    continue;
+                }
+
+                if (TryClassifyCollection(type, out _, out var rootElement, out var rootValue, unsupported))
+                {
+                    collections[type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)] = type;
+
+                    if (rootElement != null)
+                    {
+                        Visit(rootElement, queue, seen, nullables, collections, unsupported);
+                    }
+
+                    if (rootValue != null)
+                    {
+                        Visit(rootValue, queue, seen, nullables, collections, unsupported);
+                    }
 
                     continue;
                 }
@@ -64,12 +87,12 @@ namespace ModelBuilder.Generator
 
                 foreach (var parameter in SelectConstructor(type)?.Parameters ?? ImmutableArray<IParameterSymbol>.Empty)
                 {
-                    Visit(parameter.Type, queue, seen, nullables, collections);
+                    Visit(parameter.Type, queue, seen, nullables, collections, unsupported);
                 }
 
                 foreach (var property in GetSettableProperties(type))
                 {
-                    Visit(property.Type, queue, seen, nullables, collections);
+                    Visit(property.Type, queue, seen, nullables, collections, unsupported);
                 }
             }
 
@@ -96,6 +119,8 @@ namespace ModelBuilder.Generator
                 collectionModels.Add(CreateCollectionModel(pair.Value, pair.Key, sourceNames));
             }
 
+            unsupportedCollectionShapes = unsupported.OrderBy(name => name, System.StringComparer.Ordinal).ToImmutableArray();
+
             return new GenerationModel(
                 new EquatableArray<BuildableModel>(builders.ToImmutable()),
                 new EquatableArray<EnumModel>(enumModels.ToImmutable()),
@@ -103,9 +128,30 @@ namespace ModelBuilder.Generator
                 new EquatableArray<CollectionModel>(collectionModels.ToImmutable()));
         }
 
+        private static readonly HashSet<CollectionKind> _keyedCollectionKinds = new HashSet<CollectionKind>
+        {
+            CollectionKind.Dictionary,
+            CollectionKind.SortedDictionary,
+            CollectionKind.SortedList,
+            CollectionKind.ConcurrentDictionary,
+            CollectionKind.ReadOnlyDictionary,
+            CollectionKind.ImmutableDictionary,
+            CollectionKind.ImmutableSortedDictionary
+        };
+
+        private static readonly HashSet<CollectionKind> _retryOnKeyCollisionKinds = new HashSet<CollectionKind>
+        {
+            CollectionKind.SortedDictionary,
+            CollectionKind.SortedList,
+            CollectionKind.ConcurrentDictionary
+        };
+
         private static CollectionModel CreateCollectionModel(ITypeSymbol type, string slotType, HashSet<string> sourceNames)
         {
-            TryClassifyCollection(type, out var kind, out var element, out var value);
+            TryClassifyCollection(type, out var kind, out var element, out var value, null);
+
+            var keyCanBeNull = _keyedCollectionKinds.Contains(kind) && element?.IsReferenceType == true;
+            var retryOnKeyCollision = _retryOnKeyCollisionKinds.Contains(kind);
 
             return new CollectionModel(
                 kind,
@@ -113,7 +159,8 @@ namespace ModelBuilder.Generator
                 CreateName(slotType, "ValueSource", sourceNames),
                 element?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty,
                 value?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty,
-                kind == CollectionKind.Dictionary && element?.IsReferenceType == true);
+                keyCanBeNull,
+                retryOnKeyCollision);
         }
 
         private static EnumModel CreateEnumModel(INamedTypeSymbol type, string fullyQualifiedName, HashSet<string> sourceNames)
@@ -167,7 +214,8 @@ namespace ModelBuilder.Generator
             Queue<INamedTypeSymbol> queue,
             HashSet<INamedTypeSymbol> seen,
             SortedSet<string> nullables,
-            Dictionary<string, ITypeSymbol> collections)
+            Dictionary<string, ITypeSymbol> collections,
+            HashSet<string> unsupported)
         {
             if (type is IArrayTypeSymbol array)
             {
@@ -175,7 +223,7 @@ namespace ModelBuilder.Generator
                 {
                     collections[type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)] = type;
 
-                    Visit(array.ElementType, queue, seen, nullables, collections);
+                    Visit(array.ElementType, queue, seen, nullables, collections, unsupported);
                 }
 
                 return;
@@ -193,36 +241,59 @@ namespace ModelBuilder.Generator
 
                 nullables.Add(underlying.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
 
-                Visit(underlying, queue, seen, nullables, collections);
+                Visit(underlying, queue, seen, nullables, collections, unsupported);
 
                 return;
             }
 
-            if (TryClassifyCollection(named, out _, out var element, out var value))
+            if (TryClassifyCollection(named, out _, out var element, out var value, unsupported))
             {
                 collections[named.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)] = named;
 
                 if (element != null)
                 {
-                    Visit(element, queue, seen, nullables, collections);
+                    Visit(element, queue, seen, nullables, collections, unsupported);
                 }
 
                 if (value != null)
                 {
-                    Visit(value, queue, seen, nullables, collections);
+                    Visit(value, queue, seen, nullables, collections, unsupported);
                 }
 
+                return;
+            }
+
+            if (named.IsGenericType && IsUnsupportedCollectionShape(named))
+            {
                 return;
             }
 
             Enqueue(named, queue, seen);
         }
 
+
+        private static readonly string[] _unsupportedCollectionShapeDefinitions =
+        {
+            "System.ArraySegment<T>",
+            "System.Collections.Generic.Dictionary<TKey, TValue>.KeyCollection",
+            "System.Collections.Generic.Dictionary<TKey, TValue>.ValueCollection",
+            "System.Collections.Generic.SortedDictionary<TKey, TValue>.KeyCollection",
+            "System.Collections.Generic.SortedDictionary<TKey, TValue>.ValueCollection"
+        };
+
+        private static bool IsUnsupportedCollectionShape(INamedTypeSymbol named)
+        {
+            var definition = named.OriginalDefinition.ToDisplayString();
+
+            return Array.IndexOf(_unsupportedCollectionShapeDefinitions, definition) >= 0;
+        }
+
         private static bool TryClassifyCollection(
             ITypeSymbol type,
             out CollectionKind kind,
             out ITypeSymbol? element,
-            out ITypeSymbol? value)
+            out ITypeSymbol? value,
+            HashSet<string>? unsupportedShapes)
         {
             kind = CollectionKind.Array;
             element = null;
@@ -246,11 +317,19 @@ namespace ModelBuilder.Generator
                 return false;
             }
 
+            if (IsUnsupportedCollectionShape(named))
+            {
+                unsupportedShapes?.Add(named.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
+
+                return false;
+            }
+
             var definition = named.OriginalDefinition.ToDisplayString();
             var args = named.TypeArguments;
 
             switch (definition)
             {
+                // Single-type-argument, "Add"-based kinds.
                 case "System.Collections.Generic.List<T>":
                 case "System.Collections.Generic.IList<T>":
                 case "System.Collections.Generic.ICollection<T>":
@@ -263,10 +342,53 @@ namespace ModelBuilder.Generator
                     return true;
                 case "System.Collections.Generic.HashSet<T>":
                 case "System.Collections.Generic.ISet<T>":
+                case "System.Collections.Generic.IReadOnlySet<T>":
                     kind = CollectionKind.Set;
                     element = args[0];
 
                     return true;
+                case "System.Collections.ObjectModel.Collection<T>":
+                    kind = CollectionKind.Collection;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Generic.Queue<T>":
+                    kind = CollectionKind.Queue;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Generic.Stack<T>":
+                    kind = CollectionKind.Stack;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Generic.SortedSet<T>":
+                    kind = CollectionKind.SortedSet;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.ObjectModel.ObservableCollection<T>":
+                    kind = CollectionKind.ObservableCollection;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Concurrent.ConcurrentBag<T>":
+                    kind = CollectionKind.ConcurrentBag;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Concurrent.ConcurrentQueue<T>":
+                    kind = CollectionKind.ConcurrentQueue;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Concurrent.ConcurrentStack<T>":
+                    kind = CollectionKind.ConcurrentStack;
+                    element = args[0];
+
+                    return true;
+
+                // Two-type-argument, keyed kinds.
                 case "System.Collections.Generic.Dictionary<TKey, TValue>":
                 case "System.Collections.Generic.IDictionary<TKey, TValue>":
                 case "System.Collections.Generic.IReadOnlyDictionary<TKey, TValue>":
@@ -275,10 +397,98 @@ namespace ModelBuilder.Generator
                     value = args[1];
 
                     return true;
+                case "System.Collections.Generic.SortedDictionary<TKey, TValue>":
+                    kind = CollectionKind.SortedDictionary;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
+                case "System.Collections.Generic.SortedList<TKey, TValue>":
+                    kind = CollectionKind.SortedList;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
+                case "System.Collections.Concurrent.ConcurrentDictionary<TKey, TValue>":
+                    kind = CollectionKind.ConcurrentDictionary;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
+
+                // Read-only wrapper kinds.
+                case "System.Collections.ObjectModel.ReadOnlyCollection<T>":
+                    kind = CollectionKind.ReadOnlyCollection;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.ObjectModel.ReadOnlyDictionary<TKey, TValue>":
+                    kind = CollectionKind.ReadOnlyDictionary;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
+                case "System.Collections.ObjectModel.ReadOnlyObservableCollection<T>":
+                    kind = CollectionKind.ReadOnlyObservableCollection;
+                    element = args[0];
+
+                    return true;
+
+                // Immutable, single-type-argument kinds.
+                case "System.Collections.Immutable.ImmutableArray<T>":
+                    kind = CollectionKind.ImmutableArray;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Immutable.ImmutableList<T>":
+                case "System.Collections.Immutable.IImmutableList<T>":
+                    kind = CollectionKind.ImmutableList;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Immutable.ImmutableHashSet<T>":
+                case "System.Collections.Immutable.IImmutableSet<T>":
+                    kind = CollectionKind.ImmutableHashSet;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Immutable.ImmutableSortedSet<T>":
+                    kind = CollectionKind.ImmutableSortedSet;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Immutable.ImmutableQueue<T>":
+                case "System.Collections.Immutable.IImmutableQueue<T>":
+                    kind = CollectionKind.ImmutableQueue;
+                    element = args[0];
+
+                    return true;
+                case "System.Collections.Immutable.ImmutableStack<T>":
+                case "System.Collections.Immutable.IImmutableStack<T>":
+                    kind = CollectionKind.ImmutableStack;
+                    element = args[0];
+
+                    return true;
+
+                // Immutable, keyed kinds.
+                case "System.Collections.Immutable.ImmutableDictionary<TKey, TValue>":
+                case "System.Collections.Immutable.IImmutableDictionary<TKey, TValue>":
+                    kind = CollectionKind.ImmutableDictionary;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
+                case "System.Collections.Immutable.ImmutableSortedDictionary<TKey, TValue>":
+                    kind = CollectionKind.ImmutableSortedDictionary;
+                    element = args[0];
+                    value = args[1];
+
+                    return true;
                 default:
                     return false;
             }
         }
+
 
         private static BuildableModel CreateModel(
             INamedTypeSymbol type,

--- a/ModelBuilder.Generator/CollectionKind.cs
+++ b/ModelBuilder.Generator/CollectionKind.cs
@@ -9,6 +9,72 @@ namespace ModelBuilder.Generator
         Array = 0,
         List,
         Set,
-        Dictionary
+        Dictionary,
+
+        /// <summary>System.Collections.ObjectModel.Collection&lt;T&gt;.</summary>
+        Collection,
+
+        /// <summary>System.Collections.Generic.Queue&lt;T&gt;.</summary>
+        Queue,
+
+        /// <summary>System.Collections.Generic.Stack&lt;T&gt;.</summary>
+        Stack,
+
+        /// <summary>System.Collections.Generic.SortedSet&lt;T&gt;.</summary>
+        SortedSet,
+
+        /// <summary>System.Collections.ObjectModel.ObservableCollection&lt;T&gt;.</summary>
+        ObservableCollection,
+
+        /// <summary>System.Collections.Generic.SortedDictionary&lt;TKey, TValue&gt;.</summary>
+        SortedDictionary,
+
+        /// <summary>System.Collections.Generic.SortedList&lt;TKey, TValue&gt;.</summary>
+        SortedList,
+
+        /// <summary>System.Collections.Concurrent.ConcurrentDictionary&lt;TKey, TValue&gt;.</summary>
+        ConcurrentDictionary,
+
+        /// <summary>System.Collections.Concurrent.ConcurrentBag&lt;T&gt;.</summary>
+        ConcurrentBag,
+
+        /// <summary>System.Collections.Concurrent.ConcurrentQueue&lt;T&gt;.</summary>
+        ConcurrentQueue,
+
+        /// <summary>System.Collections.Concurrent.ConcurrentStack&lt;T&gt;.</summary>
+        ConcurrentStack,
+
+        /// <summary>System.Collections.ObjectModel.ReadOnlyCollection&lt;T&gt;, backed by a built List&lt;T&gt;.</summary>
+        ReadOnlyCollection,
+
+        /// <summary>System.Collections.ObjectModel.ReadOnlyDictionary&lt;TKey, TValue&gt;, backed by a built Dictionary&lt;TKey, TValue&gt;.</summary>
+        ReadOnlyDictionary,
+
+        /// <summary>System.Collections.ObjectModel.ReadOnlyObservableCollection&lt;T&gt;, backed by a built ObservableCollection&lt;T&gt;.</summary>
+        ReadOnlyObservableCollection,
+
+        /// <summary>System.Collections.Immutable.ImmutableArray&lt;T&gt;.</summary>
+        ImmutableArray,
+
+        /// <summary>System.Collections.Immutable.ImmutableList&lt;T&gt;.</summary>
+        ImmutableList,
+
+        /// <summary>System.Collections.Immutable.ImmutableHashSet&lt;T&gt;.</summary>
+        ImmutableHashSet,
+
+        /// <summary>System.Collections.Immutable.ImmutableSortedSet&lt;T&gt;.</summary>
+        ImmutableSortedSet,
+
+        /// <summary>System.Collections.Immutable.ImmutableDictionary&lt;TKey, TValue&gt;.</summary>
+        ImmutableDictionary,
+
+        /// <summary>System.Collections.Immutable.ImmutableSortedDictionary&lt;TKey, TValue&gt;.</summary>
+        ImmutableSortedDictionary,
+
+        /// <summary>System.Collections.Immutable.ImmutableQueue&lt;T&gt;.</summary>
+        ImmutableQueue,
+
+        /// <summary>System.Collections.Immutable.ImmutableStack&lt;T&gt;.</summary>
+        ImmutableStack
     }
 }

--- a/ModelBuilder.Generator/CollectionModel.cs
+++ b/ModelBuilder.Generator/CollectionModel.cs
@@ -16,7 +16,8 @@ namespace ModelBuilder.Generator
             string elementType,
             string valueType,
             bool keyCanBeNull,
-            bool retryOnKeyCollision = false)
+            bool retryOnKeyCollision = false,
+            bool isCustomType = false)
         {
             Kind = kind;
             SlotType = slotType;
@@ -25,6 +26,7 @@ namespace ModelBuilder.Generator
             ValueType = valueType;
             KeyCanBeNull = keyCanBeNull;
             RetryOnKeyCollision = retryOnKeyCollision;
+            IsCustomType = isCustomType;
         }
 
         public bool Equals(CollectionModel other)
@@ -35,7 +37,8 @@ namespace ModelBuilder.Generator
                    && string.Equals(ElementType, other.ElementType, StringComparison.Ordinal)
                    && string.Equals(ValueType, other.ValueType, StringComparison.Ordinal)
                    && KeyCanBeNull == other.KeyCanBeNull
-                   && RetryOnKeyCollision == other.RetryOnKeyCollision;
+                   && RetryOnKeyCollision == other.RetryOnKeyCollision
+                   && IsCustomType == other.IsCustomType;
         }
 
         public override bool Equals(object? obj)
@@ -55,6 +58,7 @@ namespace ModelBuilder.Generator
                 hash = hash * 397 ^ StringComparer.Ordinal.GetHashCode(ValueType);
                 hash = hash * 397 ^ KeyCanBeNull.GetHashCode();
                 hash = hash * 397 ^ RetryOnKeyCollision.GetHashCode();
+                hash = hash * 397 ^ IsCustomType.GetHashCode();
 
                 return hash;
             }
@@ -86,5 +90,14 @@ namespace ModelBuilder.Generator
         ///     Gets the value type for dictionaries; empty for other kinds.
         /// </summary>
         public string ValueType { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether <see cref="SlotType" /> is a user-defined type that was
+        ///     classified by inheriting from, or directly implementing, one of the well-known
+        ///     collection shapes rather than being one of those shapes itself. When <c>true</c>, the
+        ///     generated source constructs <see cref="SlotType" /> directly (via its own parameterless
+        ///     constructor) instead of a well-known BCL backing type.
+        /// </summary>
+        public bool IsCustomType { get; }
     }
 }

--- a/ModelBuilder.Generator/CollectionModel.cs
+++ b/ModelBuilder.Generator/CollectionModel.cs
@@ -15,7 +15,8 @@ namespace ModelBuilder.Generator
             string sourceName,
             string elementType,
             string valueType,
-            bool keyCanBeNull)
+            bool keyCanBeNull,
+            bool retryOnKeyCollision = false)
         {
             Kind = kind;
             SlotType = slotType;
@@ -23,6 +24,7 @@ namespace ModelBuilder.Generator
             ElementType = elementType;
             ValueType = valueType;
             KeyCanBeNull = keyCanBeNull;
+            RetryOnKeyCollision = retryOnKeyCollision;
         }
 
         public bool Equals(CollectionModel other)
@@ -32,7 +34,8 @@ namespace ModelBuilder.Generator
                    && string.Equals(SourceName, other.SourceName, StringComparison.Ordinal)
                    && string.Equals(ElementType, other.ElementType, StringComparison.Ordinal)
                    && string.Equals(ValueType, other.ValueType, StringComparison.Ordinal)
-                   && KeyCanBeNull == other.KeyCanBeNull;
+                   && KeyCanBeNull == other.KeyCanBeNull
+                   && RetryOnKeyCollision == other.RetryOnKeyCollision;
         }
 
         public override bool Equals(object? obj)
@@ -51,6 +54,7 @@ namespace ModelBuilder.Generator
                 hash = hash * 397 ^ StringComparer.Ordinal.GetHashCode(ElementType);
                 hash = hash * 397 ^ StringComparer.Ordinal.GetHashCode(ValueType);
                 hash = hash * 397 ^ KeyCanBeNull.GetHashCode();
+                hash = hash * 397 ^ RetryOnKeyCollision.GetHashCode();
 
                 return hash;
             }
@@ -65,6 +69,12 @@ namespace ModelBuilder.Generator
         ///     Gets a value indicating whether the dictionary key type can be <c>null</c>.
         /// </summary>
         public bool KeyCanBeNull { get; }
+
+        /// <summary>
+        ///     Gets a value indicating whether a colliding random key is retried (up to a bounded
+        ///     attempt count) rather than silently overwriting the earlier entry.
+        /// </summary>
+        public bool RetryOnKeyCollision { get; }
 
         public CollectionKind Kind { get; }
 

--- a/ModelBuilder.Generator/DiagnosticDescriptors.cs
+++ b/ModelBuilder.Generator/DiagnosticDescriptors.cs
@@ -36,5 +36,14 @@ namespace ModelBuilder.Generator
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             helpLinkUri: "https://github.com/roryprimrose/ModelBuilder");
+
+        public static readonly DiagnosticDescriptor UnsupportedCollectionShape = new DiagnosticDescriptor(
+            "MB1011",
+            "Discovered collection shape is not supported",
+            "'{0}' is a collection shape ModelBuilder does not build (it has no usable mutator, or it is a live view over another collection). Add a Model.Mapping<,> to a supported collection, or register a custom IValueSource<{0}>.",
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: "https://github.com/roryprimrose/ModelBuilder");
     }
 }

--- a/ModelBuilder.Generator/ModelBuilderGenerator.cs
+++ b/ModelBuilder.Generator/ModelBuilderGenerator.cs
@@ -81,7 +81,13 @@ namespace ModelBuilder.Generator
                 return;
             }
 
-            var models = BuildGraphWalker.Walk(distinct.Values);
+            var models = BuildGraphWalker.Walk(distinct.Values, out var unsupportedCollectionShapes);
+
+            foreach (var unsupportedShape in unsupportedCollectionShapes)
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(DiagnosticDescriptors.UnsupportedCollectionShape, Location.None, unsupportedShape));
+            }
 
             if (models.IsEmpty)
             {

--- a/ModelBuilder.Generator/SourceEmitter.cs
+++ b/ModelBuilder.Generator/SourceEmitter.cs
@@ -260,9 +260,9 @@ namespace ModelBuilder.Generator
         {
             var slot = model.SlotType;
             var element = model.ElementType;
-            var backingType = GetAddBasedBackingTypeName(kind, element);
+            var backingType = model.IsCustomType ? slot : GetAddBasedBackingTypeName(kind, element);
             var addMethod = GetAddMethodName(kind);
-            var constructorArgs = kind == CollectionKind.List ? "count" : string.Empty;
+            var constructorArgs = kind == CollectionKind.List && model.IsCustomType == false ? "count" : string.Empty;
 
             builder.Append(Indent).AppendLine($"        var result = new {backingType}({constructorArgs});");
             builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
@@ -287,7 +287,7 @@ namespace ModelBuilder.Generator
             var slot = model.SlotType;
             var element = model.ElementType;
             var value = model.ValueType;
-            var backingType = GetKeyedBackingTypeName(model.Kind, element, value);
+            var backingType = model.IsCustomType ? slot : GetKeyedBackingTypeName(model.Kind, element, value);
 
             builder.Append(Indent).AppendLine($"        var result = new {backingType}();");
             builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");

--- a/ModelBuilder.Generator/SourceEmitter.cs
+++ b/ModelBuilder.Generator/SourceEmitter.cs
@@ -143,7 +143,6 @@ namespace ModelBuilder.Generator
         private static void EmitCollectionSource(StringBuilder builder, CollectionModel model)
         {
             var slot = model.SlotType;
-            var element = model.ElementType;
 
             builder.Append(Indent).AppendLine($"internal sealed class {model.SourceName}");
             builder.Append(Indent).AppendLine($"    : global::ModelBuilder.IValueSource<{slot}>");
@@ -155,42 +154,57 @@ namespace ModelBuilder.Generator
             switch (model.Kind)
             {
                 case CollectionKind.Array:
-                    builder.Append(Indent).AppendLine($"        var result = new {element}[count];");
-                    builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
-                    builder.Append(Indent).AppendLine("        {");
-                    builder.Append(Indent).AppendLine($"            result[i] = context.Build<{element}>(typeof({slot}), \"item\");");
-                    builder.Append(Indent).AppendLine("        }");
+                    EmitArrayBody(builder, model);
 
                     break;
+                case CollectionKind.List:
                 case CollectionKind.Set:
-                    builder.Append(Indent).AppendLine($"        var result = new global::System.Collections.Generic.HashSet<{element}>();");
-                    builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
-                    builder.Append(Indent).AppendLine("        {");
-                    builder.Append(Indent).AppendLine($"            result.Add(context.Build<{element}>(typeof({slot}), \"item\"));");
-                    builder.Append(Indent).AppendLine("        }");
+                case CollectionKind.Collection:
+                case CollectionKind.Queue:
+                case CollectionKind.Stack:
+                case CollectionKind.SortedSet:
+                case CollectionKind.ObservableCollection:
+                case CollectionKind.ConcurrentBag:
+                case CollectionKind.ConcurrentQueue:
+                case CollectionKind.ConcurrentStack:
+                    EmitAddBasedBody(builder, model, model.Kind);
 
                     break;
                 case CollectionKind.Dictionary:
-                    builder.Append(Indent).AppendLine($"        var result = new global::System.Collections.Generic.Dictionary<{element}, {model.ValueType}>();");
-                    builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
-                    builder.Append(Indent).AppendLine("        {");
-                    builder.Append(Indent).AppendLine($"            var key = context.Build<{element}>(typeof({slot}), \"key\");");
+                case CollectionKind.SortedDictionary:
+                case CollectionKind.SortedList:
+                case CollectionKind.ConcurrentDictionary:
+                    EmitKeyedBody(builder, model);
 
-                    if (model.KeyCanBeNull)
-                    {
-                        builder.Append(Indent).AppendLine("            if (key is null) { continue; }");
-                    }
+                    break;
+                case CollectionKind.ReadOnlyCollection:
+                    EmitReadOnlyCollectionBody(builder, model);
 
-                    builder.Append(Indent).AppendLine($"            result[key] = context.Build<{model.ValueType}>(typeof({slot}), \"value\");");
-                    builder.Append(Indent).AppendLine("        }");
+                    break;
+                case CollectionKind.ReadOnlyDictionary:
+                    EmitReadOnlyDictionaryBody(builder, model);
+
+                    break;
+                case CollectionKind.ReadOnlyObservableCollection:
+                    EmitReadOnlyObservableCollectionBody(builder, model);
+
+                    break;
+                case CollectionKind.ImmutableArray:
+                case CollectionKind.ImmutableList:
+                case CollectionKind.ImmutableHashSet:
+                case CollectionKind.ImmutableSortedSet:
+                case CollectionKind.ImmutableQueue:
+                case CollectionKind.ImmutableStack:
+                    EmitImmutableSingleBody(builder, model);
+
+                    break;
+                case CollectionKind.ImmutableDictionary:
+                case CollectionKind.ImmutableSortedDictionary:
+                    EmitImmutableDictionaryBody(builder, model);
 
                     break;
                 default:
-                    builder.Append(Indent).AppendLine($"        var result = new global::System.Collections.Generic.List<{element}>(count);");
-                    builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
-                    builder.Append(Indent).AppendLine("        {");
-                    builder.Append(Indent).AppendLine($"            result.Add(context.Build<{element}>(typeof({slot}), \"item\"));");
-                    builder.Append(Indent).AppendLine("        }");
+                    EmitAddBasedBody(builder, model, CollectionKind.List);
 
                     break;
             }
@@ -199,6 +213,221 @@ namespace ModelBuilder.Generator
             builder.Append(Indent).AppendLine("    }");
             builder.Append(Indent).AppendLine("}");
         }
+
+        private static void EmitArrayBody(StringBuilder builder, CollectionModel model)
+        {
+            var slot = model.SlotType;
+            var element = model.ElementType;
+
+            builder.Append(Indent).AppendLine($"        var result = new {element}[count];");
+            builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
+            builder.Append(Indent).AppendLine("        {");
+            builder.Append(Indent).AppendLine($"            result[i] = context.Build<{element}>(typeof({slot}), \"item\", i);");
+            builder.Append(Indent).AppendLine("        }");
+        }
+
+        private static string GetAddBasedBackingTypeName(CollectionKind kind, string element)
+        {
+            return kind switch
+            {
+                CollectionKind.List => $"global::System.Collections.Generic.List<{element}>",
+                CollectionKind.Set => $"global::System.Collections.Generic.HashSet<{element}>",
+                CollectionKind.Collection => $"global::System.Collections.ObjectModel.Collection<{element}>",
+                CollectionKind.Queue => $"global::System.Collections.Generic.Queue<{element}>",
+                CollectionKind.Stack => $"global::System.Collections.Generic.Stack<{element}>",
+                CollectionKind.SortedSet => $"global::System.Collections.Generic.SortedSet<{element}>",
+                CollectionKind.ObservableCollection => $"global::System.Collections.ObjectModel.ObservableCollection<{element}>",
+                CollectionKind.ConcurrentBag => $"global::System.Collections.Concurrent.ConcurrentBag<{element}>",
+                CollectionKind.ConcurrentQueue => $"global::System.Collections.Concurrent.ConcurrentQueue<{element}>",
+                CollectionKind.ConcurrentStack => $"global::System.Collections.Concurrent.ConcurrentStack<{element}>",
+                _ => $"global::System.Collections.Generic.List<{element}>"
+            };
+        }
+
+        private static string GetAddMethodName(CollectionKind kind)
+        {
+            return kind switch
+            {
+                CollectionKind.Queue => "Enqueue",
+                CollectionKind.ConcurrentQueue => "Enqueue",
+                CollectionKind.Stack => "Push",
+                CollectionKind.ConcurrentStack => "Push",
+                _ => "Add"
+            };
+        }
+
+        private static void EmitAddBasedBody(StringBuilder builder, CollectionModel model, CollectionKind kind)
+        {
+            var slot = model.SlotType;
+            var element = model.ElementType;
+            var backingType = GetAddBasedBackingTypeName(kind, element);
+            var addMethod = GetAddMethodName(kind);
+            var constructorArgs = kind == CollectionKind.List ? "count" : string.Empty;
+
+            builder.Append(Indent).AppendLine($"        var result = new {backingType}({constructorArgs});");
+            builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
+            builder.Append(Indent).AppendLine("        {");
+            builder.Append(Indent).AppendLine($"            result.{addMethod}(context.Build<{element}>(typeof({slot}), \"item\", i));");
+            builder.Append(Indent).AppendLine("        }");
+        }
+
+        private static string GetKeyedBackingTypeName(CollectionKind kind, string element, string value)
+        {
+            return kind switch
+            {
+                CollectionKind.SortedDictionary => $"global::System.Collections.Generic.SortedDictionary<{element}, {value}>",
+                CollectionKind.SortedList => $"global::System.Collections.Generic.SortedList<{element}, {value}>",
+                CollectionKind.ConcurrentDictionary => $"global::System.Collections.Concurrent.ConcurrentDictionary<{element}, {value}>",
+                _ => $"global::System.Collections.Generic.Dictionary<{element}, {value}>"
+            };
+        }
+
+        private static void EmitKeyedBody(StringBuilder builder, CollectionModel model)
+        {
+            var slot = model.SlotType;
+            var element = model.ElementType;
+            var value = model.ValueType;
+            var backingType = GetKeyedBackingTypeName(model.Kind, element, value);
+
+            builder.Append(Indent).AppendLine($"        var result = new {backingType}();");
+            builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
+            builder.Append(Indent).AppendLine("        {");
+
+            if (model.RetryOnKeyCollision)
+            {
+                builder.Append(Indent).AppendLine($"            {element} key;");
+                builder.Append(Indent).AppendLine("            var attempts = 0;");
+                builder.Append(Indent).AppendLine("            do");
+                builder.Append(Indent).AppendLine("            {");
+                builder.Append(Indent).AppendLine($"                key = context.Build<{element}>(typeof({slot}), \"key\", i);");
+                builder.Append(Indent).AppendLine("                attempts++;");
+                builder.Append(Indent).AppendLine("            }");
+
+                if (model.KeyCanBeNull)
+                {
+                    builder.Append(Indent).AppendLine("            while ((key is null || result.ContainsKey(key)) && attempts < 10);");
+                    builder.Append(Indent).AppendLine("            if (key is null) { continue; }");
+                }
+                else
+                {
+                    builder.Append(Indent).AppendLine("            while (result.ContainsKey(key) && attempts < 10);");
+                }
+            }
+            else
+            {
+                builder.Append(Indent).AppendLine($"            var key = context.Build<{element}>(typeof({slot}), \"key\", i);");
+
+                if (model.KeyCanBeNull)
+                {
+                    builder.Append(Indent).AppendLine("            if (key is null) { continue; }");
+                }
+            }
+
+            builder.Append(Indent).AppendLine($"            result[key] = context.Build<{value}>(typeof({slot}), \"value\", i);");
+            builder.Append(Indent).AppendLine("        }");
+        }
+
+        private static void EmitReadOnlyCollectionBody(StringBuilder builder, CollectionModel model)
+        {
+            var slot = model.SlotType;
+            var element = model.ElementType;
+
+            builder.Append(Indent).AppendLine($"        var backing = new global::System.Collections.Generic.List<{element}>(count);");
+            builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
+            builder.Append(Indent).AppendLine("        {");
+            builder.Append(Indent).AppendLine($"            backing.Add(context.Build<{element}>(typeof({slot}), \"item\", i));");
+            builder.Append(Indent).AppendLine("        }");
+            builder.Append(Indent).AppendLine($"        var result = new global::System.Collections.ObjectModel.ReadOnlyCollection<{element}>(backing);");
+        }
+
+        private static void EmitReadOnlyDictionaryBody(StringBuilder builder, CollectionModel model)
+        {
+            var slot = model.SlotType;
+            var element = model.ElementType;
+            var value = model.ValueType;
+
+            builder.Append(Indent).AppendLine($"        var backing = new global::System.Collections.Generic.Dictionary<{element}, {value}>();");
+            builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
+            builder.Append(Indent).AppendLine("        {");
+            builder.Append(Indent).AppendLine($"            var key = context.Build<{element}>(typeof({slot}), \"key\", i);");
+
+            if (model.KeyCanBeNull)
+            {
+                builder.Append(Indent).AppendLine("            if (key is null) { continue; }");
+            }
+
+            builder.Append(Indent).AppendLine($"            backing[key] = context.Build<{value}>(typeof({slot}), \"value\", i);");
+            builder.Append(Indent).AppendLine("        }");
+            builder.Append(Indent)
+                .AppendLine($"        var result = new global::System.Collections.ObjectModel.ReadOnlyDictionary<{element}, {value}>(backing);");
+        }
+
+        private static void EmitReadOnlyObservableCollectionBody(StringBuilder builder, CollectionModel model)
+        {
+            var slot = model.SlotType;
+            var element = model.ElementType;
+
+            builder.Append(Indent).AppendLine($"        var backing = new global::System.Collections.ObjectModel.ObservableCollection<{element}>();");
+            builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
+            builder.Append(Indent).AppendLine("        {");
+            builder.Append(Indent).AppendLine($"            backing.Add(context.Build<{element}>(typeof({slot}), \"item\", i));");
+            builder.Append(Indent).AppendLine("        }");
+            builder.Append(Indent)
+                .AppendLine($"        var result = new global::System.Collections.ObjectModel.ReadOnlyObservableCollection<{element}>(backing);");
+        }
+
+        private static string GetImmutableFactoryTypeName(CollectionKind kind)
+        {
+            return kind switch
+            {
+                CollectionKind.ImmutableArray => "global::System.Collections.Immutable.ImmutableArray",
+                CollectionKind.ImmutableList => "global::System.Collections.Immutable.ImmutableList",
+                CollectionKind.ImmutableHashSet => "global::System.Collections.Immutable.ImmutableHashSet",
+                CollectionKind.ImmutableSortedSet => "global::System.Collections.Immutable.ImmutableSortedSet",
+                CollectionKind.ImmutableQueue => "global::System.Collections.Immutable.ImmutableQueue",
+                CollectionKind.ImmutableStack => "global::System.Collections.Immutable.ImmutableStack",
+                CollectionKind.ImmutableDictionary => "global::System.Collections.Immutable.ImmutableDictionary",
+                CollectionKind.ImmutableSortedDictionary => "global::System.Collections.Immutable.ImmutableSortedDictionary",
+                _ => "global::System.Collections.Immutable.ImmutableList"
+            };
+        }
+
+        private static void EmitImmutableSingleBody(StringBuilder builder, CollectionModel model)
+        {
+            var slot = model.SlotType;
+            var element = model.ElementType;
+            var factory = GetImmutableFactoryTypeName(model.Kind);
+
+            builder.Append(Indent).AppendLine($"        var backing = new global::System.Collections.Generic.List<{element}>(count);");
+            builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
+            builder.Append(Indent).AppendLine("        {");
+            builder.Append(Indent).AppendLine($"            backing.Add(context.Build<{element}>(typeof({slot}), \"item\", i));");
+            builder.Append(Indent).AppendLine("        }");
+            builder.Append(Indent).AppendLine($"        var result = {factory}.CreateRange(backing);");
+        }
+
+        private static void EmitImmutableDictionaryBody(StringBuilder builder, CollectionModel model)
+        {
+            var slot = model.SlotType;
+            var element = model.ElementType;
+            var value = model.ValueType;
+            var factory = GetImmutableFactoryTypeName(model.Kind);
+
+            builder.Append(Indent).AppendLine($"        var backing = new global::System.Collections.Generic.Dictionary<{element}, {value}>();");
+            builder.Append(Indent).AppendLine("        for (var i = 0; i < count; i++)");
+            builder.Append(Indent).AppendLine("        {");
+            builder.Append(Indent).AppendLine($"            var key = context.Build<{element}>(typeof({slot}), \"key\", i);");
+
+            if (model.KeyCanBeNull)
+            {
+                builder.Append(Indent).AppendLine("            if (key is null) { continue; }");
+            }
+
+            builder.Append(Indent).AppendLine($"            backing[key] = context.Build<{value}>(typeof({slot}), \"value\", i);");
+            builder.Append(Indent).AppendLine("        }");
+            builder.Append(Indent).AppendLine($"        var result = {factory}.CreateRange(backing);");
+        }
+
 
         private static void EmitBuilder(StringBuilder builder, BuildableModel model)
         {
@@ -515,16 +744,23 @@ namespace ModelBuilder.Generator
             foreach (var enumModel in model.Enums)
             {
                 builder.Append(Indent).AppendLine($"        global::ModelBuilder.ValueSource<{enumModel.FullyQualifiedName}>.Instance = new {enumModel.SourceName}();");
+                builder.Append(Indent)
+                    .AppendLine($"        global::ModelBuilder.Model.RegisterValueSource<{enumModel.FullyQualifiedName}>(new {enumModel.SourceName}());");
             }
 
             foreach (var underlying in model.NullableUnderlyingTypes)
             {
                 builder.Append(Indent).AppendLine($"        global::ModelBuilder.ValueSource<{underlying}?>.Instance = new global::ModelBuilder.NullableValueSource<{underlying}>();");
+                builder.Append(Indent)
+                    .AppendLine(
+                        $"        global::ModelBuilder.Model.RegisterValueSource<{underlying}?>(new global::ModelBuilder.NullableValueSource<{underlying}>());");
             }
 
             foreach (var collection in model.Collections)
             {
                 builder.Append(Indent).AppendLine($"        global::ModelBuilder.ValueSource<{collection.SlotType}>.Instance = new {collection.SourceName}();");
+                builder.Append(Indent)
+                    .AppendLine($"        global::ModelBuilder.Model.RegisterValueSource<{collection.SlotType}>(new {collection.SourceName}());");
             }
 
             foreach (var buildable in model.Builders)

--- a/ModelBuilder.IntegrationTests/CircularReferenceTests.cs
+++ b/ModelBuilder.IntegrationTests/CircularReferenceTests.cs
@@ -1,0 +1,54 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests that a self-referencing type and a pair of mutually referencing types build
+    ///     without infinite recursion, terminating a cycle by leaving the repeated member at its default
+    ///     rather than looping or overflowing the stack.
+    /// </summary>
+    public class CircularReferenceTests
+    {
+        [Fact]
+        public void CreateTerminatesSelfReferencingChainWithoutStackOverflow()
+        {
+            var actual = Model.Create<GraphNode>();
+
+            actual.Should().NotBeNull();
+            actual.Name.Should().NotBeNullOrWhiteSpace();
+
+            // The chain must terminate somewhere: walking Next repeatedly must not run forever. 200 hops
+            // is far beyond the default MaxDepth (50), so reaching it without hitting a null Next would
+            // itself indicate the guard failed to terminate the cycle.
+            var current = actual;
+            var hops = 0;
+
+            while (current!.Next != null && hops < 200)
+            {
+                current = current.Next;
+                hops++;
+            }
+
+            hops.Should().BeLessThan(200);
+        }
+
+        [Fact]
+        public void CreateTerminatesMutuallyReferencingTypesWithoutStackOverflow()
+        {
+            var actual = Model.Create<Manager>();
+
+            actual.Should().NotBeNull();
+            actual.Name.Should().NotBeNullOrWhiteSpace();
+            actual.DirectReports.Should().NotBeEmpty();
+
+            // Each report's own Manager must not itself carry another populated DirectReports chain
+            // forever; the guard should have left it null/empty once the cycle is detected.
+            foreach (var report in actual.DirectReports)
+            {
+                report.Name.Should().NotBeNullOrWhiteSpace();
+            }
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/CollectionTests.cs
+++ b/ModelBuilder.IntegrationTests/CollectionTests.cs
@@ -1,0 +1,48 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests that every recognized BCL collection kind populates both its shape (Count)
+    ///     and a fully built element/key/value graph, using <c>SetOptions</c> to force a known size.
+    /// </summary>
+    public class CollectionTests
+    {
+        [Fact]
+        public void CreatePopulatesEveryCollectionKindWithFullyBuiltElements()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 3;
+                    x.MaxCount = 3;
+                })
+                .Create<CollectionsProfile>();
+
+            actual.ArrayItems.Should().HaveCount(3);
+            actual.ArrayItems.Should().OnlyContain(w => w.Name != string.Empty);
+
+            actual.ListItems.Should().HaveCount(3);
+            actual.SetItems.Should().HaveCount(3);
+            actual.CollectionItems.Should().HaveCount(3);
+            actual.QueueItems.Should().HaveCount(3);
+            actual.StackItems.Should().HaveCount(3);
+            actual.SortedSetItems.Should().HaveCount(3);
+            actual.ObservableItems.Should().HaveCount(3);
+            actual.ConcurrentBagItems.Should().HaveCount(3);
+            actual.ConcurrentQueueItems.Should().HaveCount(3);
+            actual.ConcurrentStackItems.Should().HaveCount(3);
+            actual.DictionaryItems.Should().HaveCount(3);
+            actual.SortedDictionaryItems.Should().HaveCount(3);
+            actual.SortedListItems.Should().HaveCount(3);
+            actual.ConcurrentDictionaryItems.Should().HaveCount(3);
+            actual.ReadOnlyCollectionItems.Should().HaveCount(3);
+            actual.ReadOnlyDictionaryItems.Should().HaveCount(3);
+
+            // Spot-check that elements are fully built graphs (non-default Widget), not empty shells.
+            actual.ListItems.Should().OnlyContain(w => w.Name != string.Empty && w.Price != 0);
+            actual.DictionaryItems.Values.Should().OnlyContain(w => w.Name != string.Empty);
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/ConstructionTests.cs
+++ b/ModelBuilder.IntegrationTests/ConstructionTests.cs
@@ -1,0 +1,66 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of constructor selection: the greediest public constructor is used for
+    ///     <c>Model.Create&lt;T&gt;()</c>, and every public constructor gets a matching typed
+    ///     <c>Model.Construct&lt;T&gt;().From(...)</c> overload.
+    /// </summary>
+    public class ConstructionTests
+    {
+        [Fact]
+        public void CreateUsesParameterlessConstructorWhenAvailable()
+        {
+            // Model.Create<T>() always prefers the parameterless constructor over any parameterized
+            // overload (design.md 5.2 "Compile-time constructor choice"), unlike v8's greedy
+            // DefaultConstructorResolver. Use Model.Construct<T>().From(...) to reach the others.
+            var actual = Model.Create<MultiConstructorWidget>();
+
+            actual.Name.Should().Be("Default");
+            actual.Quantity.Should().Be(0);
+            actual.Price.Should().Be(0);
+        }
+
+        [Fact]
+        public void ConstructFromParameterlessOverloadUsesDefaults()
+        {
+            var actual = Model.Construct<MultiConstructorWidget>().From();
+
+            actual.Name.Should().Be("Default");
+            actual.Quantity.Should().Be(0);
+            actual.Price.Should().Be(0);
+        }
+
+        [Fact]
+        public void ConstructFromSingleArgumentOverloadKeepsSuppliedValue()
+        {
+            var actual = Model.Construct<MultiConstructorWidget>().From("Explicit");
+
+            actual.Name.Should().Be("Explicit");
+            actual.Quantity.Should().Be(0);
+        }
+
+        [Fact]
+        public void ConstructFromTwoArgumentOverloadKeepsSuppliedValues()
+        {
+            var actual = Model.Construct<MultiConstructorWidget>().From("Explicit", 5);
+
+            actual.Name.Should().Be("Explicit");
+            actual.Quantity.Should().Be(5);
+            actual.Price.Should().Be(0);
+        }
+
+        [Fact]
+        public void ConstructFromThreeArgumentOverloadKeepsAllSuppliedValues()
+        {
+            var actual = Model.Construct<MultiConstructorWidget>().From("Explicit", 5, 12.5m);
+
+            actual.Name.Should().Be("Explicit");
+            actual.Quantity.Should().Be(5);
+            actual.Price.Should().Be(12.5m);
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/CustomCollectionTests.cs
+++ b/ModelBuilder.IntegrationTests/CustomCollectionTests.cs
@@ -1,0 +1,56 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of the custom-collection-type support: a type inheriting a mutable BCL
+    ///     collection base, a type inheriting a keyed BCL collection base, and a hand-written
+    ///     <see cref="System.Collections.Generic.IList{T}" /> implementer.
+    /// </summary>
+    public class CustomCollectionTests
+    {
+        [Fact]
+        public void CreateBuildsCustomTypeInheritingCollectionWithItems()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 2;
+                    x.MaxCount = 2;
+                })
+                .Create<WidgetBag>();
+
+            actual.Should().HaveCount(2);
+            actual.Should().OnlyContain(w => w.Name != string.Empty);
+        }
+
+        [Fact]
+        public void CreateBuildsCustomTypeInheritingDictionaryWithItems()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 2;
+                    x.MaxCount = 2;
+                })
+                .Create<WidgetMap>();
+
+            actual.Should().HaveCount(2);
+            actual.Values.Should().OnlyContain(w => w.Name != string.Empty);
+        }
+
+        [Fact]
+        public void CreateBuildsCustomIListImplementerWithItems()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 2;
+                    x.MaxCount = 2;
+                })
+                .Create<CustomWidgetList>();
+
+            actual.Should().HaveCount(2);
+            actual.Should().OnlyContain(w => w.Name != string.Empty);
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/CustomValueSourceTests.cs
+++ b/ModelBuilder.IntegrationTests/CustomValueSourceTests.cs
@@ -1,0 +1,45 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of custom value sources: an ad-hoc <see cref="DelegateValueSource{T}" /> and a
+    ///     reusable named <see cref="IValueSource{T}" /> class registered via <c>AddValueSource</c>.
+    /// </summary>
+    public class CustomValueSourceTests
+    {
+        [Fact]
+        public void CreateUsesSingleArgumentDelegateValueSourceForNamedMember()
+        {
+            var actual = Model
+                .AddValueSource(new DelegateValueSource<string>(_ => "fixed-name"), nameof(Widget.Name))
+                .Create<Widget>();
+
+            actual.Name.Should().Be("fixed-name");
+        }
+
+        [Fact]
+        public void CreateUsesTwoArgumentDelegateValueSourceForNamedMember()
+        {
+            var actual = Model
+                .AddValueSource(
+                    new DelegateValueSource<string>((context, target) => $"{target.Type.Name}-{target.MemberName}"),
+                    nameof(Widget.Name))
+                .Create<Widget>();
+
+            actual.Name.Should().Be("String-Name");
+        }
+
+        [Fact]
+        public void CreateUsesReusableNamedValueSourceForMatchingMemberName()
+        {
+            var actual = Model.AddValueSource(new SkuValueSource(), nameof(Product.Sku)).Create<Product>();
+
+            actual.Sku.Should().StartWith("SKU-");
+            actual.Name.Should().NotBeNullOrWhiteSpace();
+            actual.Price.Should().NotBe(0);
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/EnumTests.cs
+++ b/ModelBuilder.IntegrationTests/EnumTests.cs
@@ -1,0 +1,32 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using System;
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests that enum roots and members always resolve to a defined value, including
+    ///     <c>[Flags]</c> enums.
+    /// </summary>
+    public class EnumTests
+    {
+        [Fact]
+        public void CreateBuildsDefinedSimpleEnumValue()
+        {
+            var actual = Model.Create<Colour>();
+
+            Enum.IsDefined(typeof(Colour), actual).Should().BeTrue();
+        }
+
+        [Fact]
+        public void CreateBuildsDefinedFlagsEnumValue()
+        {
+            var actual = Model.Create<Permissions>();
+
+            // A flags enum's build should stay within the declared bit range rather than an arbitrary
+            // out-of-range integer.
+            ((actual & ~Permissions.All) == 0).Should().BeTrue();
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/FailureHandlingTests.cs
+++ b/ModelBuilder.IntegrationTests/FailureHandlingTests.cs
@@ -1,0 +1,29 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using System;
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end test that a value source throwing during a build surfaces as a
+    ///     <see cref="ModelBuildException" /> categorized as <see cref="FailureKind.ValueSourceThrew" />
+    ///     with the failing type and member identified.
+    /// </summary>
+    public class FailureHandlingTests
+    {
+        [Fact]
+        public void CreateWrapsThrowingValueSourceInModelBuildException()
+        {
+            var source = new DelegateValueSource<string>(_ => throw new InvalidOperationException("boom"));
+
+            Action act = () => Model.AddValueSource(source, nameof(Widget.Name)).Create<Widget>();
+
+            var exception = act.Should().Throw<ModelBuildException>().Which;
+
+            exception.FailureKind.Should().Be(FailureKind.ValueSourceThrew);
+            exception.TargetMember.Should().Be(nameof(Widget.Name));
+            exception.InnerException.Should().BeOfType<InvalidOperationException>();
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/IgnoringTests.cs
+++ b/ModelBuilder.IntegrationTests/IgnoringTests.cs
@@ -1,0 +1,55 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of member exclusion via typed <c>Ignoring</c>, type+name <c>Ignoring</c>, and
+    ///     predicate-based <c>IgnoringAny</c>, confirming ignored members are left at their default while
+    ///     other members still populate normally.
+    /// </summary>
+    public class IgnoringTests
+    {
+        [Fact]
+        public void CreateLeavesTypedIgnoredMemberAtDefault()
+        {
+            var actual = Model.Ignoring<Credentials>(x => x.Password).Create<Credentials>();
+
+            // An ignored member is never assigned, so it retains its field-initializer default
+            // (string.Empty) rather than receiving a built value.
+            actual.Password.Should().BeEmpty();
+            actual.Username.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public void CreateLeavesTypeAndNameIgnoredMemberAtDefault()
+        {
+            var actual = Model.Ignoring(typeof(Credentials), nameof(Credentials.Password)).Create<Credentials>();
+
+            actual.Password.Should().BeEmpty();
+            actual.Username.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public void CreateLeavesPredicateMatchedMemberAtDefault()
+        {
+            var actual = Model.IgnoringAny(member => member.Name.EndsWith("Secret", System.StringComparison.Ordinal))
+                .Create<Credentials>();
+
+            actual.ApiKeySecret.Should().BeEmpty();
+            actual.Username.Should().NotBeNullOrWhiteSpace();
+            actual.Password.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public void CreateAppliesAllIgnoreRulesFromConfigurationModule()
+        {
+            var actual = Model.UsingModule<IntegrationTestModule>().Create<Credentials>();
+
+            actual.Password.Should().BeEmpty();
+            actual.ApiKeySecret.Should().BeEmpty();
+            actual.Username.Should().NotBeNullOrWhiteSpace();
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/LoggingTests.cs
+++ b/ModelBuilder.IntegrationTests/LoggingTests.cs
@@ -1,0 +1,28 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end test that <c>Model.WriteLog</c> captures a non-empty, structured build log
+    ///     describing a nested build.
+    /// </summary>
+    public class LoggingTests
+    {
+        [Fact]
+        public void WriteLogCapturesRenderedBuildLogForNestedGraph()
+        {
+            string? capturedLog = null;
+
+            var actual = Model.WriteLog(log => capturedLog = log).Create<Invoice>();
+
+            actual.Should().NotBeNull();
+            capturedLog.Should().NotBeNullOrWhiteSpace();
+
+            // The rendered log should mention the root type and at least one nested member name.
+            capturedLog.Should().Contain(nameof(Invoice));
+            capturedLog.Should().Contain(nameof(Invoice.Reference));
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/MappingTests.cs
+++ b/ModelBuilder.IntegrationTests/MappingTests.cs
@@ -1,0 +1,34 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of interface-to-concrete-type mapping via <c>Model.Mapping&lt;TSource,TTarget&gt;()</c>
+    ///     and via a configuration module registering the same mapping.
+    /// </summary>
+    public class MappingTests
+    {
+        [Fact]
+        public void CreatePopulatesInterfaceMemberUsingFluentMapping()
+        {
+            var actual = Model.Mapping<IEngine, DieselEngine>().Create<Vehicle>();
+
+            actual.Model.Should().NotBeNullOrWhiteSpace();
+            actual.Engine.Should().NotBeNull();
+            actual.Engine.Should().BeOfType<DieselEngine>();
+            actual.Engine!.Name.Should().NotBeNullOrWhiteSpace();
+            actual.Engine.Horsepower.Should().NotBe(0);
+        }
+
+        [Fact]
+        public void CreatePopulatesInterfaceMemberUsingConfigurationModuleMapping()
+        {
+            var actual = Model.UsingModule<IntegrationTestModule>().Create<Vehicle>();
+
+            actual.Engine.Should().NotBeNull();
+            actual.Engine.Should().BeOfType<DieselEngine>();
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/ModelBuilder.IntegrationTests.csproj
+++ b/ModelBuilder.IntegrationTests/ModelBuilder.IntegrationTests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!--
+      net472 exercises the netstandard2.0 consumption path (mirrors ModelBuilder.BenchmarkTests); the
+      modern TFMs cover the AOT-capable runtimes. The same scenario suite runs unchanged on each so any
+      per-TFM behavioral drift in the generator or runtime is caught.
+    -->
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
+    <CodeAnalysisRuleSet>..\Solution Items\UnitTest.ruleset</CodeAnalysisRuleSet>
+
+    <!-- xUnit v3 runs on the Microsoft Testing Platform, which requires an executable test host. -->
+    <OutputType>Exe</OutputType>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ModelBuilder\ModelBuilder.csproj" />
+    <!-- Explicit so the generator reliably runs on every TFM above, including net472. -->
+    <ProjectReference Include="..\ModelBuilder.Generator\ModelBuilder.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
+  </ItemGroup>
+
+</Project>

--- a/ModelBuilder.IntegrationTests/Models/CollectionsProfile.cs
+++ b/ModelBuilder.IntegrationTests/Models/CollectionsProfile.cs
@@ -1,0 +1,49 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+
+    /// <summary>
+    ///     Exposes one settable member per collection kind the generator recognizes, using
+    ///     <see cref="Widget" /> (a non-trivial element type) so both the collection shape and the item
+    ///     graph population can be verified in one build.
+    /// </summary>
+    public class CollectionsProfile
+    {
+        public Widget[] ArrayItems { get; set; } = System.Array.Empty<Widget>();
+
+        public List<Widget> ListItems { get; set; } = new();
+
+        public HashSet<Widget> SetItems { get; set; } = new();
+
+        public Collection<Widget> CollectionItems { get; set; } = new();
+
+        public Queue<Widget> QueueItems { get; set; } = new();
+
+        public Stack<Widget> StackItems { get; set; } = new();
+
+        public SortedSet<int> SortedSetItems { get; set; } = new();
+
+        public ObservableCollection<Widget> ObservableItems { get; set; } = new();
+
+        public ConcurrentBag<Widget> ConcurrentBagItems { get; set; } = new();
+
+        public ConcurrentQueue<Widget> ConcurrentQueueItems { get; set; } = new();
+
+        public ConcurrentStack<Widget> ConcurrentStackItems { get; set; } = new();
+
+        public Dictionary<string, Widget> DictionaryItems { get; set; } = new();
+
+        public SortedDictionary<string, Widget> SortedDictionaryItems { get; set; } = new();
+
+        public SortedList<string, Widget> SortedListItems { get; set; } = new();
+
+        public ConcurrentDictionary<string, Widget> ConcurrentDictionaryItems { get; set; } = new();
+
+        public ReadOnlyCollection<Widget> ReadOnlyCollectionItems { get; set; } = new(new List<Widget>());
+
+        public ReadOnlyDictionary<string, Widget> ReadOnlyDictionaryItems { get; set; } =
+            new(new Dictionary<string, Widget>());
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/Colour.cs
+++ b/ModelBuilder.IntegrationTests/Models/Colour.cs
@@ -1,0 +1,14 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A simple enum used to verify enum members always resolve to a defined value.
+    /// </summary>
+    public enum Colour
+    {
+        Red = 0,
+
+        Green = 1,
+
+        Blue = 2
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/Credentials.cs
+++ b/ModelBuilder.IntegrationTests/Models/Credentials.cs
@@ -1,0 +1,15 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A class with members intended to be ignored in tests — a strongly typed member, a
+    ///     type-and-name pair, and a member matched by an <c>IgnoringAny</c> naming predicate.
+    /// </summary>
+    public class Credentials
+    {
+        public string Username { get; set; } = string.Empty;
+
+        public string Password { get; set; } = string.Empty;
+
+        public string ApiKeySecret { get; set; } = string.Empty;
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/CustomCollections.cs
+++ b/ModelBuilder.IntegrationTests/Models/CustomCollections.cs
@@ -1,0 +1,92 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+
+    /// <summary>
+    ///     A custom type that inherits a mutable BCL collection base, used to verify the generator
+    ///     builds the requested type itself (not a substitute <see cref="Collection{T}" />) end to end.
+    /// </summary>
+    public class WidgetBag : Collection<Widget>
+    {
+        public string BagLabel { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    ///     A custom type that inherits <see cref="Dictionary{TKey,TValue}" />, used to verify keyed
+    ///     custom-collection construction end to end.
+    /// </summary>
+    public class WidgetMap : Dictionary<string, Widget>
+    {
+    }
+
+    /// <summary>
+    ///     A hand-written <see cref="IList{T}" /> implementer (does not inherit any BCL collection base)
+    ///     used to verify the interface-implementation classification path end to end.
+    /// </summary>
+    public class CustomWidgetList : IList<Widget>
+    {
+        private readonly List<Widget> _items = new();
+
+        public Widget this[int index]
+        {
+            get => _items[index];
+            set => _items[index] = value;
+        }
+
+        public int Count => _items.Count;
+
+        public bool IsReadOnly => false;
+
+        public void Add(Widget item)
+        {
+            _items.Add(item);
+        }
+
+        public void Clear()
+        {
+            _items.Clear();
+        }
+
+        public bool Contains(Widget item)
+        {
+            return _items.Contains(item);
+        }
+
+        public void CopyTo(Widget[] array, int arrayIndex)
+        {
+            _items.CopyTo(array, arrayIndex);
+        }
+
+        public IEnumerator<Widget> GetEnumerator()
+        {
+            return _items.GetEnumerator();
+        }
+
+        public int IndexOf(Widget item)
+        {
+            return _items.IndexOf(item);
+        }
+
+        public void Insert(int index, Widget item)
+        {
+            _items.Insert(index, item);
+        }
+
+        public bool Remove(Widget item)
+        {
+            return _items.Remove(item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            _items.RemoveAt(index);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/GraphNode.cs
+++ b/ModelBuilder.IntegrationTests/Models/GraphNode.cs
@@ -1,0 +1,36 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    ///     A self-referencing type used to verify the depth/circular-reference guard prevents infinite
+    ///     recursion when a member's type matches an ancestor already being built.
+    /// </summary>
+    public class GraphNode
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public GraphNode? Next { get; set; }
+    }
+
+    /// <summary>
+    ///     Two mutually referencing types (rather than a single type referencing itself) used to verify
+    ///     the same guard applies across a cycle spanning more than one type.
+    /// </summary>
+    public class Employee
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public Manager? Manager { get; set; }
+    }
+
+    /// <summary>
+    ///     See <see cref="Employee" />.
+    /// </summary>
+    public class Manager
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public List<Employee> DirectReports { get; set; } = new();
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/IntegrationTestModule.cs
+++ b/ModelBuilder.IntegrationTests/Models/IntegrationTestModule.cs
@@ -1,0 +1,24 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    using System;
+
+    /// <summary>
+    ///     A reusable <see cref="IConfigurationModule" /> bundling a mapping, an ignore rule, an
+    ///     <c>IgnoringAny</c> predicate and an option override, so
+    ///     <c>Model.UsingModule&lt;IntegrationTestModule&gt;()</c> can be verified end to end.
+    /// </summary>
+    public sealed class IntegrationTestModule : IConfigurationModule
+    {
+        /// <inheritdoc />
+        public void Configure(IBuildConfiguration configuration)
+        {
+            configuration.AddMapping<IEngine, DieselEngine>();
+
+            configuration.Ignore(typeof(Credentials), nameof(Credentials.Password));
+
+            configuration.IgnoreAny(member => member.Name.EndsWith("Secret", StringComparison.Ordinal));
+
+            configuration.SetOptions(x => x.MaxCount = 3);
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/Invoice.cs
+++ b/ModelBuilder.IntegrationTests/Models/Invoice.cs
@@ -1,0 +1,23 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A base class whose settable properties should populate on a derived type just like its own.
+    /// </summary>
+    public class AuditableEntity
+    {
+        public System.Guid Id { get; set; }
+
+        public System.DateTime CreatedOn { get; set; }
+    }
+
+    /// <summary>
+    ///     A derived type mixing its own members with inherited ones, to verify the generator populates
+    ///     both.
+    /// </summary>
+    public class Invoice : AuditableEntity
+    {
+        public string Reference { get; set; } = string.Empty;
+
+        public decimal Total { get; set; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/MultiConstructorWidget.cs
+++ b/ModelBuilder.IntegrationTests/Models/MultiConstructorWidget.cs
@@ -1,0 +1,39 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     Exposes several public constructors of increasing arity so tests can confirm the generator
+    ///     selects the greediest constructor for <c>Model.Create&lt;T&gt;()</c> and that
+    ///     <c>Model.Construct&lt;T&gt;().From(...)</c> exposes one typed overload per constructor.
+    /// </summary>
+    public class MultiConstructorWidget
+    {
+        public MultiConstructorWidget()
+        {
+            Name = "Default";
+        }
+
+        public MultiConstructorWidget(string name)
+        {
+            Name = name;
+        }
+
+        public MultiConstructorWidget(string name, int quantity)
+        {
+            Name = name;
+            Quantity = quantity;
+        }
+
+        public MultiConstructorWidget(string name, int quantity, decimal price)
+        {
+            Name = name;
+            Quantity = quantity;
+            Price = price;
+        }
+
+        public string Name { get; }
+
+        public int Quantity { get; }
+
+        public decimal Price { get; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/NullableProfile.cs
+++ b/ModelBuilder.IntegrationTests/Models/NullableProfile.cs
@@ -1,0 +1,27 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    using System;
+
+    /// <summary>
+    ///     Pairs a nullable member with its non-nullable counterpart so tests can assert both build
+    ///     consistently under different <see cref="ModelBuilder.BuildOptions.NullPercentage" /> settings.
+    /// </summary>
+    public class NullableProfile
+    {
+        public int? NullableInt { get; set; }
+
+        public int NonNullableInt { get; set; }
+
+        public DateTime? NullableDate { get; set; }
+
+        public Guid? NullableGuid { get; set; }
+
+        public bool? NullableBool { get; set; }
+
+        public Colour? NullableColour { get; set; }
+
+        public string? NullableText { get; set; }
+
+        public string NonNullableText { get; set; } = string.Empty;
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/NumericBoundaries.cs
+++ b/ModelBuilder.IntegrationTests/Models/NumericBoundaries.cs
@@ -1,0 +1,36 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A class exposing every numeric primitive plus <see cref="char" /> and <see cref="bool" />, so
+    ///     a single build can assert every numeric kind populates without overflow or type-conversion
+    ///     failures.
+    /// </summary>
+    public class NumericBoundaries
+    {
+        public sbyte SByteValue { get; set; }
+
+        public byte ByteValue { get; set; }
+
+        public short ShortValue { get; set; }
+
+        public ushort UShortValue { get; set; }
+
+        public int IntValue { get; set; }
+
+        public uint UIntValue { get; set; }
+
+        public long LongValue { get; set; }
+
+        public ulong ULongValue { get; set; }
+
+        public float FloatValue { get; set; }
+
+        public double DoubleValue { get; set; }
+
+        public decimal DecimalValue { get; set; }
+
+        public char CharValue { get; set; }
+
+        public bool BoolValue { get; set; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/Permissions.cs
+++ b/ModelBuilder.IntegrationTests/Models/Permissions.cs
@@ -1,0 +1,22 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    using System;
+
+    /// <summary>
+    ///     A <c>[Flags]</c> enum used to verify flags-shaped enums build to a defined (possibly
+    ///     combined) value rather than an arbitrary out-of-range integer.
+    /// </summary>
+    [Flags]
+    public enum Permissions
+    {
+        None = 0,
+
+        Read = 1,
+
+        Write = 2,
+
+        Execute = 4,
+
+        All = Read | Write | Execute
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/Product.cs
+++ b/ModelBuilder.IntegrationTests/Models/Product.cs
@@ -1,0 +1,14 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A class whose <see cref="Sku" /> member is targeted by the custom-named-value-source tests.
+    /// </summary>
+    public class Product
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public string Sku { get; set; } = string.Empty;
+
+        public decimal Price { get; set; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/ShapeProfile.cs
+++ b/ModelBuilder.IntegrationTests/Models/ShapeProfile.cs
@@ -1,0 +1,25 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A value type (struct) used to verify struct roots and struct-typed members build correctly.
+    /// </summary>
+    public struct PointStruct
+    {
+        public int X { get; set; }
+
+        public int Y { get; set; }
+    }
+
+    /// <summary>
+    ///     A class holding a plain struct member and a nullable struct member, to verify both shapes
+    ///     populate.
+    /// </summary>
+    public class ShapeProfile
+    {
+        public PointStruct Origin { get; set; }
+
+        public PointStruct? Bounds { get; set; }
+
+        public string Label { get; set; } = string.Empty;
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/SkuValueSource.cs
+++ b/ModelBuilder.IntegrationTests/Models/SkuValueSource.cs
@@ -1,0 +1,18 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    using ModelBuilder;
+
+    /// <summary>
+    ///     A reusable <see cref="IValueSource{T}" /> class (as opposed to an inline
+    ///     <see cref="DelegateValueSource{T}" />) used to verify a promoted, named value source is
+    ///     matched and invoked.
+    /// </summary>
+    public sealed class SkuValueSource : IValueSource<string>
+    {
+        /// <inheritdoc />
+        public string Create(IBuildContext context, in BuildTarget target)
+        {
+            return "SKU-" + context.Random.NextInt32(10000, 99999);
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/Vehicle.cs
+++ b/ModelBuilder.IntegrationTests/Models/Vehicle.cs
@@ -1,0 +1,35 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     An interface with a single concrete implementation, used to verify
+    ///     <c>Model.Mapping&lt;TSource, TTarget&gt;()</c> resolves an interface-typed member to a
+    ///     concrete built instance.
+    /// </summary>
+    public interface IEngine
+    {
+        string Name { get; }
+
+        int Horsepower { get; }
+    }
+
+    /// <summary>
+    ///     The concrete <see cref="IEngine" /> implementation mapped in the mapping scenario tests.
+    /// </summary>
+    public class DieselEngine : IEngine
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public int Horsepower { get; set; }
+    }
+
+    /// <summary>
+    ///     A class with an interface-typed member that has no default concrete type, requiring a
+    ///     <c>Model.Mapping&lt;,&gt;()</c> registration for the build to populate it.
+    /// </summary>
+    public class Vehicle
+    {
+        public string Model { get; set; } = string.Empty;
+
+        public IEngine? Engine { get; set; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/Widget.cs
+++ b/ModelBuilder.IntegrationTests/Models/Widget.cs
@@ -1,0 +1,12 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A leaf class used as the element type for collection scenarios across the integration suite.
+    /// </summary>
+    public class Widget
+    {
+        public string Name { get; set; } = string.Empty;
+
+        public decimal Price { get; set; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/NullableTests.cs
+++ b/ModelBuilder.IntegrationTests/NullableTests.cs
@@ -1,0 +1,46 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of nullable value/reference type members under both extremes of
+    ///     <see cref="ModelBuilder.BuildOptions.NullPercentage" />.
+    /// </summary>
+    public class NullableTests
+    {
+        [Fact]
+        public void CreatePopulatesAllNullableMembersWhenNullPercentageIsZero()
+        {
+            var actual = Model.SetOptions(x => x.NullPercentage = 0).Create<NullableProfile>();
+
+            actual.NullableInt.Should().NotBeNull();
+            actual.NullableDate.Should().NotBeNull();
+            actual.NullableGuid.Should().NotBeNull();
+            actual.NullableBool.Should().NotBeNull();
+            actual.NullableColour.Should().NotBeNull();
+            actual.NullableText.Should().NotBeNull();
+            actual.NonNullableInt.Should().NotBe(0);
+            actual.NonNullableText.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public void CreateLeavesAllNullableMembersNullWhenNullPercentageIsMaxed()
+        {
+            var actual = Model.SetOptions(x => x.NullPercentage = 100).Create<NullableProfile>();
+
+            actual.NullableInt.Should().BeNull();
+            actual.NullableDate.Should().BeNull();
+            actual.NullableGuid.Should().BeNull();
+            actual.NullableBool.Should().BeNull();
+            actual.NullableColour.Should().BeNull();
+
+            // NullPercentage only governs Nullable<T> value types. A nullable-annotated reference type
+            // (string?) has no distinct runtime representation from a non-nullable string, so it
+            // continues to build a real value regardless of NullPercentage, exactly like NonNullableText.
+            actual.NullableText.Should().NotBeNull();
+            actual.NonNullableText.Should().NotBeNullOrWhiteSpace();
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/NumericBoundaryTests.cs
+++ b/ModelBuilder.IntegrationTests/NumericBoundaryTests.cs
@@ -1,0 +1,50 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests that every numeric primitive kind populates a non-default, in-range value
+    ///     without overflow or type-conversion failures.
+    /// </summary>
+    public class NumericBoundaryTests
+    {
+        [Fact]
+        public void CreatePopulatesEveryNumericPrimitiveWithoutThrowing()
+        {
+            var actual = Model.Create<NumericBoundaries>();
+
+            actual.Should().NotBeNull();
+
+            // sbyte/byte/short/ushort/etc. all deserialize within their declared CLR type's range by
+            // construction (the assignment above would throw OverflowException/InvalidCastException at
+            // runtime if the generator produced an out-of-range literal or the wrong numeric type).
+            actual.CharValue.Should().NotBe('\0');
+        }
+
+        [Fact]
+        public void CreateProducesVariedValuesAcrossRepeatedBuildsForEachNumericMember()
+        {
+            var first = Model.Create<NumericBoundaries>();
+            var second = Model.Create<NumericBoundaries>();
+
+            // Not every single member is guaranteed to differ between two builds, but requiring the
+            // whole set of numeric members to match by coincidence across two independent builds is
+            // vanishingly unlikely, so this proves real randomization rather than fixed literals.
+            var same = first.SByteValue == second.SByteValue
+                       && first.ByteValue == second.ByteValue
+                       && first.ShortValue == second.ShortValue
+                       && first.UShortValue == second.UShortValue
+                       && first.IntValue == second.IntValue
+                       && first.UIntValue == second.UIntValue
+                       && first.LongValue == second.LongValue
+                       && first.ULongValue == second.ULongValue
+                       && first.FloatValue.Equals(second.FloatValue)
+                       && first.DoubleValue.Equals(second.DoubleValue)
+                       && first.DecimalValue == second.DecimalValue;
+
+            same.Should().BeFalse();
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/PopulateTests.cs
+++ b/ModelBuilder.IntegrationTests/PopulateTests.cs
@@ -1,0 +1,36 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of <c>Model.Populate</c> filling in an existing instance's settable members,
+    ///     combined with an ignore rule to confirm the excluded member is left untouched.
+    /// </summary>
+    public class PopulateTests
+    {
+        [Fact]
+        public void PopulateFillsSettableMembersOfExistingInstance()
+        {
+            var instance = new Widget();
+
+            var actual = Model.Populate(instance);
+
+            actual.Should().BeSameAs(instance);
+            actual.Name.Should().NotBeNullOrWhiteSpace();
+            actual.Price.Should().NotBe(0);
+        }
+
+        [Fact]
+        public void PopulateAppliesIgnoreRuleFromConfiguration()
+        {
+            var instance = new Credentials();
+
+            var actual = Model.Ignoring<Credentials>(x => x.Password).Populate(instance);
+
+            actual.Password.Should().BeEmpty();
+            actual.Username.Should().NotBeNullOrWhiteSpace();
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/PostBuildTests.cs
+++ b/ModelBuilder.IntegrationTests/PostBuildTests.cs
@@ -1,0 +1,54 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of the post-build helpers: <c>Set</c> for a single instance and
+    ///     <c>SetEach</c> (plain and indexed) for a collection of built instances.
+    /// </summary>
+    public class PostBuildTests
+    {
+        [Fact]
+        public void SetAppliesChangeAfterCreate()
+        {
+            var actual = Model.Create<Widget>().Set(x => x.Name = "Overridden");
+
+            actual.Name.Should().Be("Overridden");
+        }
+
+        [Fact]
+        public void SetEachAppliesChangeToEveryItemInList()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 3;
+                    x.MaxCount = 3;
+                })
+                .Create<List<Widget>>()
+                .SetEach(x => x.Price = 1.5m);
+
+            actual.Should().HaveCount(3);
+            actual.Should().OnlyContain(w => w.Price == 1.5m);
+        }
+
+        [Fact]
+        public void SetEachByIndexAppliesIndexDependentChangeToEveryItemInList()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 3;
+                    x.MaxCount = 3;
+                })
+                .Create<List<Widget>>()
+                .SetEach((index, x) => x.Name = $"Widget-{index}");
+
+            actual.Should().HaveCount(3);
+            actual[0].Name.Should().Be("Widget-0");
+            actual[1].Name.Should().Be("Widget-1");
+            actual[2].Name.Should().Be("Widget-2");
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/PropertyPopulationTests.cs
+++ b/ModelBuilder.IntegrationTests/PropertyPopulationTests.cs
@@ -1,0 +1,24 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of settable-property population, including members inherited from a base
+    ///     class.
+    /// </summary>
+    public class PropertyPopulationTests
+    {
+        [Fact]
+        public void CreatePopulatesOwnAndInheritedSettableProperties()
+        {
+            var actual = Model.Create<Invoice>();
+
+            actual.Id.Should().NotBeEmpty();
+            actual.CreatedOn.Should().NotBe(default(System.DateTime));
+            actual.Reference.Should().NotBeNullOrWhiteSpace();
+            actual.Total.Should().NotBe(0);
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/StructTests.cs
+++ b/ModelBuilder.IntegrationTests/StructTests.cs
@@ -1,0 +1,47 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of struct roots and struct-typed members, including nullable structs.
+    /// </summary>
+    public class StructTests
+    {
+        [Fact]
+        public void CreateBuildsStructRootDirectly()
+        {
+            var actual = Model.Create<PointStruct>();
+
+            // A struct root is a value-source root like any primitive; either coordinate being
+            // non-default is enough to prove real values were generated rather than default(T).
+            (actual.X != 0 || actual.Y != 0).Should().BeTrue();
+        }
+
+        [Fact]
+        public void CreatePopulatesStructMember()
+        {
+            var actual = Model.Create<ShapeProfile>();
+
+            actual.Label.Should().NotBeNullOrWhiteSpace();
+            (actual.Origin.X != 0 || actual.Origin.Y != 0).Should().BeTrue();
+        }
+
+        [Fact]
+        public void CreatePopulatesNullableStructMemberWhenNullPercentageIsZero()
+        {
+            var actual = Model.SetOptions(x => x.NullPercentage = 0).Create<ShapeProfile>();
+
+            actual.Bounds.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void CreateLeavesNullableStructMemberNullWhenNullPercentageIsMaxed()
+        {
+            var actual = Model.SetOptions(x => x.NullPercentage = 100).Create<ShapeProfile>();
+
+            actual.Bounds.Should().BeNull();
+        }
+    }
+}

--- a/ModelBuilder.IntegrationTests/TuningOptionsTests.cs
+++ b/ModelBuilder.IntegrationTests/TuningOptionsTests.cs
@@ -1,0 +1,53 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using System.Collections.Generic;
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of the tuning options exposed on <see cref="BuildOptions" />: collection size
+    ///     bounds, maximum graph depth, and applying a module that sets options centrally.
+    /// </summary>
+    public class TuningOptionsTests
+    {
+        [Fact]
+        public void SetOptionsBoundsCollectionSizeBetweenMinAndMax()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 2;
+                    x.MaxCount = 4;
+                })
+                .Create<List<Widget>>();
+
+            actual.Count.Should().BeGreaterThanOrEqualTo(2);
+            actual.Count.Should().BeLessThanOrEqualTo(4);
+        }
+
+        [Fact]
+        public void SetOptionsMaxDepthTerminatesSelfReferencingChainAtConfiguredDepth()
+        {
+            var actual = Model.SetOptions(x => x.MaxDepth = 2).Create<GraphNode>();
+
+            var current = actual;
+            var hops = 0;
+
+            while (current!.Next != null && hops < 10)
+            {
+                current = current.Next;
+                hops++;
+            }
+
+            hops.Should().BeLessThan(10);
+        }
+
+        [Fact]
+        public void ConfigurationModuleAppliesMaxCountAcrossBuild()
+        {
+            var actual = Model.UsingModule<IntegrationTestModule>().Create<CollectionsProfile>();
+
+            actual.ListItems.Count.Should().BeLessThanOrEqualTo(3);
+        }
+    }
+}

--- a/ModelBuilder.UnitTests/BuildContextTests.cs
+++ b/ModelBuilder.UnitTests/BuildContextTests.cs
@@ -146,6 +146,74 @@
             sut.Random.Should().BeSameAs(random);
         }
 
+        [Fact]
+        public void BuildWithCollectionIndexRecordsIndexOnBuildFrame()
+        {
+            int? capturedIndex = null;
+
+            var configuration = new BuildConfiguration();
+
+            configuration.AddValueSource(
+                new DelegateValueSource<string>(context =>
+                {
+                    capturedIndex = ((BuildContext)context).BuildPath[^1].CollectionIndex;
+
+                    return "value";
+                }));
+
+            var sut = new BuildContext(new RandomSource(1), configuration: configuration);
+
+            sut.Build<string>(typeof(Order), "item", 3);
+
+            capturedIndex.Should().Be(3);
+        }
+
+        [Fact]
+        public void BuildWithoutCollectionIndexLeavesBuildFrameIndexNull()
+        {
+            int? capturedIndex = 0;
+
+            var configuration = new BuildConfiguration();
+
+            configuration.AddValueSource(
+                new DelegateValueSource<string>(context =>
+                {
+                    capturedIndex = ((BuildContext)context).BuildPath[^1].CollectionIndex;
+
+                    return "value";
+                }));
+
+            var sut = new BuildContext(new RandomSource(1), configuration: configuration);
+
+            sut.Build<string>(typeof(Order), "Name");
+
+            capturedIndex.Should().BeNull();
+        }
+
+        [Fact]
+        public void BuildNestsLogEntriesUnderTheValueSourceScope()
+        {
+            var configuration = new BuildConfiguration();
+
+            configuration.AddValueSource(
+                new DelegateValueSource<Customer>(context =>
+                {
+                    context.Build<string>(typeof(Customer), "Name");
+
+                    return new Customer();
+                }));
+
+            var log = new BuildLog();
+            var sut = new BuildContext(new RandomSource(1), log, configuration: configuration);
+
+            sut.Build<Customer>(typeof(Order), "Customer");
+
+            log.Entries.Should().ContainSingle();
+            log.Entries[0].MemberName.Should().Be("Customer");
+            log.Entries[0].Children.Should().ContainSingle();
+            log.Entries[0].Children[0].MemberName.Should().Be("Name");
+        }
+
         private sealed class Customer
         {
         }

--- a/ModelBuilder.UnitTests/BuildContextTests.cs
+++ b/ModelBuilder.UnitTests/BuildContextTests.cs
@@ -156,7 +156,9 @@
             configuration.AddValueSource(
                 new DelegateValueSource<string>(context =>
                 {
-                    capturedIndex = ((BuildContext)context).BuildPath[^1].CollectionIndex;
+                    var buildPath = ((BuildContext)context).BuildPath;
+
+                    capturedIndex = buildPath[buildPath.Count - 1].CollectionIndex;
 
                     return "value";
                 }));
@@ -178,7 +180,9 @@
             configuration.AddValueSource(
                 new DelegateValueSource<string>(context =>
                 {
-                    capturedIndex = ((BuildContext)context).BuildPath[^1].CollectionIndex;
+                    var buildPath = ((BuildContext)context).BuildPath;
+
+                    capturedIndex = buildPath[buildPath.Count - 1].CollectionIndex;
 
                     return "value";
                 }));

--- a/ModelBuilder.UnitTests/BuildFrameTests.cs
+++ b/ModelBuilder.UnitTests/BuildFrameTests.cs
@@ -15,6 +15,15 @@
             sut.DeclaringType.Should().Be(typeof(Uri));
             sut.MemberName.Should().Be("Endpoint");
             sut.MemberType.Should().Be(typeof(string));
+            sut.CollectionIndex.Should().BeNull();
+        }
+
+        [Fact]
+        public void ConstructorStoresCollectionIndex()
+        {
+            var sut = new BuildFrame(typeof(Uri), "item", typeof(string), 3);
+
+            sut.CollectionIndex.Should().Be(3);
         }
 
         [Fact]

--- a/ModelBuilder.UnitTests/BuildLogTests.cs
+++ b/ModelBuilder.UnitTests/BuildLogTests.cs
@@ -88,6 +88,28 @@
             sut.Entries[0].TargetType.Should().Be(typeof(Guid));
         }
 
+        [Fact]
+        public void WriteStoresCollectionIndex()
+        {
+            var sut = new BuildLog();
+
+            sut.Write(BuildLogEntryKind.CreateValue, typeof(int), "item", collectionIndex: 2);
+
+            sut.Entries[0].CollectionIndex.Should().Be(2);
+        }
+
+        [Fact]
+        public void BeginScopeStoresCollectionIndex()
+        {
+            var sut = new BuildLog();
+
+            using (sut.BeginScope(BuildLogEntryKind.CreateValue, typeof(int), "item", collectionIndex: 5))
+            {
+            }
+
+            sut.Entries[0].CollectionIndex.Should().Be(5);
+        }
+
         private sealed class Person
         {
         }

--- a/ModelBuilder.UnitTests/ModelBuilder.UnitTests.csproj
+++ b/ModelBuilder.UnitTests/ModelBuilder.UnitTests.csproj
@@ -1,7 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <!--
+      net472 exercises the netstandard2.0 consumption path (mirrors ModelBuilder.BenchmarkTests and
+      ModelBuilder.IntegrationTests); the modern TFMs cover the AOT-capable runtimes. The same test
+      suite runs unchanged on each so any per-TFM behavioral drift in the generator or runtime is caught.
+    -->
+    <TargetFrameworks>net472;net8.0;net9.0;net10.0</TargetFrameworks>
     <CodeAnalysisRuleSet>..\Solution Items\UnitTest.ruleset</CodeAnalysisRuleSet>
 
     <!-- xUnit v3 runs on the Microsoft Testing Platform, which requires an executable test host. -->
@@ -29,6 +34,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ModelBuilder\ModelBuilder.csproj" />
+    <!-- Explicit so the generator reliably runs on every TFM above, including net472. -->
+    <ProjectReference Include="..\ModelBuilder.Generator\ModelBuilder.Generator.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ModelBuilder.UnitTests/ModelFacadeTests.cs
+++ b/ModelBuilder.UnitTests/ModelFacadeTests.cs
@@ -81,6 +81,25 @@
         }
 
         [Fact]
+        public void CreateTypeUsesRegisteredValueSourceFactoryWhenNoBuilderRegistered()
+        {
+            global::ModelBuilder.Model.RegisterValueSource(new ValueSourceOnlySource());
+
+            var actual = global::ModelBuilder.Model.Create(typeof(ValueSourceOnly));
+
+            actual.Should().BeOfType<ValueSourceOnly>();
+            ((ValueSourceOnly)actual).Value.Should().Be(42);
+        }
+
+        [Fact]
+        public void RegisterValueSourceThrowsWithNullSource()
+        {
+            Action action = () => global::ModelBuilder.Model.RegisterValueSource<ValueSourceOnly>(null!);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
         public void PopulateUsesSlotBuilder()
         {
             ModelBuilderSlot<Widget>.Instance = new WidgetBuilder();
@@ -102,6 +121,19 @@
 
         private sealed class Unregistered
         {
+        }
+
+        private sealed class ValueSourceOnly
+        {
+            public int Value { get; set; }
+        }
+
+        private sealed class ValueSourceOnlySource : IValueSource<ValueSourceOnly>
+        {
+            public ValueSourceOnly Create(IBuildContext context, in BuildTarget target)
+            {
+                return new ValueSourceOnly { Value = 42 };
+            }
         }
 
         private sealed class Widget

--- a/ModelBuilder.UnitTests/ValueSourceRegistryTests.cs
+++ b/ModelBuilder.UnitTests/ValueSourceRegistryTests.cs
@@ -39,6 +39,33 @@
             source.Should().BeNull();
         }
 
+        [Fact]
+        public void TryCreateBoxedReturnsTrueAndBoxedValueForRegisteredType()
+        {
+            var sut = new ValueSourceRegistry();
+            sut.Register<int>(new ConstantInt32Source());
+
+            var context = new BuildContext(new RandomSource(1));
+
+            var actual = sut.TryCreateBoxed(typeof(int), context, out var value);
+
+            actual.Should().BeTrue();
+            value.Should().Be(7);
+        }
+
+        [Fact]
+        public void TryCreateBoxedReturnsFalseForUnregisteredType()
+        {
+            var sut = new ValueSourceRegistry();
+
+            var context = new BuildContext(new RandomSource(1));
+
+            var actual = sut.TryCreateBoxed(typeof(int), context, out var value);
+
+            actual.Should().BeFalse();
+            value.Should().BeNull();
+        }
+
         private sealed class ConstantInt32Source : IValueSource<int>
         {
             public int Create(IBuildContext context, in BuildTarget target)

--- a/ModelBuilder.slnx
+++ b/ModelBuilder.slnx
@@ -28,6 +28,7 @@
   <Project Path="ModelBuilder.Examples/ModelBuilder.Examples.csproj" />
   <Project Path="ModelBuilder.Generator/ModelBuilder.Generator.csproj" />
   <Project Path="ModelBuilder.Generator.UnitTests/ModelBuilder.Generator.UnitTests.csproj" />
+  <Project Path="ModelBuilder.IntegrationTests/ModelBuilder.IntegrationTests.csproj" />
   <Project Path="ModelBuilder.UnitTests/ModelBuilder.UnitTests.csproj" />
   <Project Path="ModelBuilder/ModelBuilder.csproj" />
 </Solution>

--- a/ModelBuilder/BuildContext.cs
+++ b/ModelBuilder/BuildContext.cs
@@ -98,18 +98,22 @@ namespace ModelBuilder
         /// <param name="declaringType">The type that declares the member.</param>
         /// <param name="memberName">The name of the member.</param>
         /// <param name="memberType">The type of the member.</param>
+        /// <param name="collectionIndex">
+        ///     The zero-based index of the item within an enclosing collection, or <c>null</c> when this
+        ///     frame is not a collection item.
+        /// </param>
         /// <returns>A token that exits the frame when disposed.</returns>
         /// <exception cref="ArgumentNullException">
         ///     The <paramref name="declaringType" />, <paramref name="memberName" />, or
         ///     <paramref name="memberType" /> parameter is <c>null</c>.
         /// </exception>
-        internal IDisposable EnterMember(Type declaringType, string memberName, Type memberType)
+        internal IDisposable EnterMember(Type declaringType, string memberName, Type memberType, int? collectionIndex = null)
         {
             declaringType = declaringType ?? throw new ArgumentNullException(nameof(declaringType));
             memberName = memberName ?? throw new ArgumentNullException(nameof(memberName));
             memberType = memberType ?? throw new ArgumentNullException(nameof(memberType));
 
-            return Enter(new BuildFrame(declaringType, memberName, memberType));
+            return Enter(new BuildFrame(declaringType, memberName, memberType, collectionIndex));
         }
 
         /// <summary>
@@ -218,6 +222,17 @@ namespace ModelBuilder
         /// <inheritdoc />
         public T Build<T>(Type declaringType, string memberName)
         {
+            return BuildCore<T>(declaringType, memberName, null);
+        }
+
+        /// <inheritdoc />
+        public T Build<T>(Type declaringType, string memberName, int collectionIndex)
+        {
+            return BuildCore<T>(declaringType, memberName, collectionIndex);
+        }
+
+        private T BuildCore<T>(Type declaringType, string memberName, int? collectionIndex)
+        {
             declaringType = declaringType ?? throw new ArgumentNullException(nameof(declaringType));
             memberName = memberName ?? throw new ArgumentNullException(nameof(memberName));
 
@@ -227,14 +242,14 @@ namespace ModelBuilder
             {
                 if (IsInBuildChain(mappedType))
                 {
-                    Log.Write(BuildLogEntryKind.SkipMember, mappedType, memberName, "circular-reference guard");
+                    Log.Write(BuildLogEntryKind.SkipMember, mappedType, memberName, "circular-reference guard", collectionIndex);
 
                     return default!;
                 }
 
                 if (Model.RegistryInternal.TryGet(mappedType, out var mappedBuilder) && mappedBuilder != null)
                 {
-                    using (EnterMember(declaringType, memberName, mappedType))
+                    using (EnterMember(declaringType, memberName, mappedType, collectionIndex))
                     {
                         return (T)Invoke(memberName, () => mappedBuilder.Create(this));
                     }
@@ -250,9 +265,8 @@ namespace ModelBuilder
                 && _buildConfiguration.CustomNamedValueSources!.TryGet<T>(memberName, out var customNamed)
                 && customNamed != null)
             {
-                Log.Write(BuildLogEntryKind.CreateValue, memberType, memberName, "custom named value source");
-
-                using (EnterMember(declaringType, memberName, memberType))
+                using (Log.BeginScope(BuildLogEntryKind.CreateValue, memberType, memberName, "custom named value source", collectionIndex))
+                using (EnterMember(declaringType, memberName, memberType, collectionIndex))
                 {
                     return Invoke(memberName, () => customNamed.Create(this, new BuildTarget(memberType, memberName)));
                 }
@@ -263,9 +277,8 @@ namespace ModelBuilder
                 && _buildConfiguration.CustomValueSources!.TryGet<T>(out var customTyped)
                 && customTyped != null)
             {
-                Log.Write(BuildLogEntryKind.CreateValue, memberType, memberName, "custom value source");
-
-                using (EnterMember(declaringType, memberName, memberType))
+                using (Log.BeginScope(BuildLogEntryKind.CreateValue, memberType, memberName, "custom value source", collectionIndex))
+                using (EnterMember(declaringType, memberName, memberType, collectionIndex))
                 {
                     return Invoke(memberName, () => customTyped.Create(this, new BuildTarget(memberType, memberName)));
                 }
@@ -275,9 +288,8 @@ namespace ModelBuilder
 
             if (source != null)
             {
-                Log.Write(BuildLogEntryKind.CreateValue, memberType, memberName, "registered value source");
-
-                using (EnterMember(declaringType, memberName, memberType))
+                using (Log.BeginScope(BuildLogEntryKind.CreateValue, memberType, memberName, "registered value source", collectionIndex))
+                using (EnterMember(declaringType, memberName, memberType, collectionIndex))
                 {
                     return Invoke(memberName, () => source.Create(this, new BuildTarget(memberType, memberName)));
                 }
@@ -285,9 +297,8 @@ namespace ModelBuilder
 
             if (NamedValueSources.TryGet<T>(memberName, out var named) && named != null)
             {
-                Log.Write(BuildLogEntryKind.CreateValue, memberType, memberName, "named value source");
-
-                using (EnterMember(declaringType, memberName, memberType))
+                using (Log.BeginScope(BuildLogEntryKind.CreateValue, memberType, memberName, "named value source", collectionIndex))
+                using (EnterMember(declaringType, memberName, memberType, collectionIndex))
                 {
                     return Invoke(memberName, () => named.Create(this, new BuildTarget(memberType, memberName)));
                 }
@@ -295,9 +306,8 @@ namespace ModelBuilder
 
             if (TryResolveValueSource<T>(out var builtIn) && builtIn != null)
             {
-                Log.Write(BuildLogEntryKind.CreateValue, memberType, memberName, "built-in value source");
-
-                using (EnterMember(declaringType, memberName, memberType))
+                using (Log.BeginScope(BuildLogEntryKind.CreateValue, memberType, memberName, "built-in value source", collectionIndex))
+                using (EnterMember(declaringType, memberName, memberType, collectionIndex))
                 {
                     return Invoke(memberName, () => builtIn.Create(this, new BuildTarget(memberType, memberName)));
                 }
@@ -312,19 +322,19 @@ namespace ModelBuilder
 
             if (IsInBuildChain(memberType))
             {
-                Log.Write(BuildLogEntryKind.SkipMember, memberType, memberName, "circular-reference guard");
+                Log.Write(BuildLogEntryKind.SkipMember, memberType, memberName, "circular-reference guard", collectionIndex);
 
                 return default!;
             }
 
             if (IsDepthExceeded)
             {
-                Log.Write(BuildLogEntryKind.SkipMember, memberType, memberName, "depth guard");
+                Log.Write(BuildLogEntryKind.SkipMember, memberType, memberName, "depth guard", collectionIndex);
 
                 return default!;
             }
 
-            using (EnterMember(declaringType, memberName, memberType))
+            using (EnterMember(declaringType, memberName, memberType, collectionIndex))
             {
                 return Invoke(memberName, () => builder.Create(this));
             }
@@ -346,9 +356,10 @@ namespace ModelBuilder
             {
                 var target = new BuildTarget(targetType, targetType.Name);
 
-                Log.Write(BuildLogEntryKind.CreateValue, targetType, targetType.Name, "root value source");
-
-                value = Invoke(targetType.Name, () => source.Create(this, target));
+                using (Log.BeginScope(BuildLogEntryKind.CreateValue, targetType, targetType.Name, "root value source"))
+                {
+                    value = Invoke(targetType.Name, () => source.Create(this, target));
+                }
 
                 return true;
             }

--- a/ModelBuilder/BuildFrame.cs
+++ b/ModelBuilder/BuildFrame.cs
@@ -15,15 +15,26 @@ namespace ModelBuilder
         /// <param name="declaringType">The type that declares the member being built.</param>
         /// <param name="memberName">The name of the member being built, or <c>null</c> for the root.</param>
         /// <param name="memberType">The type of the value being built at this frame.</param>
+        /// <param name="collectionIndex">
+        ///     The zero-based index of the item within an enclosing collection, or <c>null</c> when this
+        ///     frame is not a collection item.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         ///     The <paramref name="declaringType" /> or <paramref name="memberType" /> parameter is <c>null</c>.
         /// </exception>
-        public BuildFrame(Type declaringType, string? memberName, Type memberType)
+        public BuildFrame(Type declaringType, string? memberName, Type memberType, int? collectionIndex = null)
         {
             DeclaringType = declaringType ?? throw new ArgumentNullException(nameof(declaringType));
             MemberType = memberType ?? throw new ArgumentNullException(nameof(memberType));
             MemberName = memberName;
+            CollectionIndex = collectionIndex;
         }
+
+        /// <summary>
+        ///     Gets the zero-based index of the item within an enclosing collection.
+        /// </summary>
+        /// <returns>The item index, or <c>null</c> when this frame is not a collection item.</returns>
+        public int? CollectionIndex { get; }
 
         /// <summary>
         ///     Gets the type that declares the member being built.

--- a/ModelBuilder/BuildLog.cs
+++ b/ModelBuilder/BuildLog.cs
@@ -20,11 +20,12 @@ namespace ModelBuilder
             BuildLogEntryKind kind,
             Type targetType,
             string? memberName = null,
-            string? reason = null)
+            string? reason = null,
+            int? collectionIndex = null)
         {
             targetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
 
-            var entry = new BuildLogEntry(kind, targetType, memberName, reason);
+            var entry = new BuildLogEntry(kind, targetType, memberName, reason, collectionIndex);
 
             AddEntry(entry);
             _scopes.Push(entry);
@@ -53,11 +54,12 @@ namespace ModelBuilder
             BuildLogEntryKind kind,
             Type targetType,
             string? memberName = null,
-            string? reason = null)
+            string? reason = null,
+            int? collectionIndex = null)
         {
             targetType = targetType ?? throw new ArgumentNullException(nameof(targetType));
 
-            AddEntry(new BuildLogEntry(kind, targetType, memberName, reason));
+            AddEntry(new BuildLogEntry(kind, targetType, memberName, reason, collectionIndex));
         }
 
         private static void RenderEntry(StringBuilder builder, BuildLogEntry entry, int depth)

--- a/ModelBuilder/BuildLogEntry.cs
+++ b/ModelBuilder/BuildLogEntry.cs
@@ -12,12 +12,13 @@ namespace ModelBuilder
     {
         private readonly List<BuildLogEntry> _children = new List<BuildLogEntry>();
 
-        internal BuildLogEntry(BuildLogEntryKind kind, Type targetType, string? memberName, string? reason)
+        internal BuildLogEntry(BuildLogEntryKind kind, Type targetType, string? memberName, string? reason, int? collectionIndex = null)
         {
             Kind = kind;
             TargetType = targetType;
             MemberName = memberName;
             Reason = reason;
+            CollectionIndex = collectionIndex;
         }
 
         internal void Add(BuildLogEntry child)
@@ -29,6 +30,12 @@ namespace ModelBuilder
         ///     Gets the child entries nested beneath this entry.
         /// </summary>
         public IReadOnlyList<BuildLogEntry> Children => _children;
+
+        /// <summary>
+        ///     Gets the zero-based index of the item within an enclosing collection.
+        /// </summary>
+        /// <returns>The item index, or <c>null</c> when this entry does not relate to a collection item.</returns>
+        public int? CollectionIndex { get; }
 
         /// <summary>
         ///     Gets the kind of action this entry records.

--- a/ModelBuilder/IBuildContext.cs
+++ b/ModelBuilder/IBuildContext.cs
@@ -6,8 +6,8 @@ namespace ModelBuilder
     ///     The <see cref="IBuildContext" /> interface
     ///     is the per-build surface shared with generated builders and custom value sources. It exposes
     ///     the random source, build log, configuration, sibling-scope access, and the recursive
-    ///     <see cref="Build{T}" /> entry point, without leaking the engine's internal build chain,
-    ///     depth guards, or registries.
+    ///     <see cref="Build{T}(Type, string)" /> entry point, without leaking the engine's internal build
+    ///     chain, depth guards, or registries.
     /// </summary>
     public interface IBuildContext
     {
@@ -58,6 +58,20 @@ namespace ModelBuilder
         ///     The <paramref name="declaringType" /> or <paramref name="memberName" /> parameter is <c>null</c>.
         /// </exception>
         T Build<T>(Type declaringType, string memberName);
+
+        /// <summary>
+        ///     Builds a value for an item within a collection, recording its zero-based index on the
+        ///     build path and build log so failures and traces can identify which item failed.
+        /// </summary>
+        /// <typeparam name="T">The item type to build.</typeparam>
+        /// <param name="declaringType">The collection type that declares the item.</param>
+        /// <param name="memberName">The name of the member (for example <c>"item"</c> or <c>"key"</c>).</param>
+        /// <param name="collectionIndex">The zero-based index of the item within the collection.</param>
+        /// <returns>The built value, or <c>default</c> when no source or builder is registered or a guard fired.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The <paramref name="declaringType" /> or <paramref name="memberName" /> parameter is <c>null</c>.
+        /// </exception>
+        T Build<T>(Type declaringType, string memberName, int collectionIndex);
 
         /// <summary>
         ///     Opens a sibling scope for the instance currently being populated, so that members already

--- a/ModelBuilder/IBuildLog.cs
+++ b/ModelBuilder/IBuildLog.cs
@@ -17,12 +17,16 @@ namespace ModelBuilder
         /// <param name="targetType">The type the scope relates to.</param>
         /// <param name="memberName">The optional name of the member the scope relates to.</param>
         /// <param name="reason">The optional reason recorded for the scope.</param>
+        /// <param name="collectionIndex">
+        ///     The optional zero-based index of the item within an enclosing collection.
+        /// </param>
         /// <returns>A token that ends the scope when disposed.</returns>
         IDisposable BeginScope(
             BuildLogEntryKind kind,
             Type targetType,
             string? memberName = null,
-            string? reason = null);
+            string? reason = null,
+            int? collectionIndex = null);
 
         /// <summary>
         ///     Records a leaf entry beneath the current scope.
@@ -31,11 +35,15 @@ namespace ModelBuilder
         /// <param name="targetType">The type the entry relates to.</param>
         /// <param name="memberName">The optional name of the member the entry relates to.</param>
         /// <param name="reason">The optional reason recorded for the entry.</param>
+        /// <param name="collectionIndex">
+        ///     The optional zero-based index of the item within an enclosing collection.
+        /// </param>
         void Write(
             BuildLogEntryKind kind,
             Type targetType,
             string? memberName = null,
-            string? reason = null);
+            string? reason = null,
+            int? collectionIndex = null);
 
         /// <summary>
         ///     Gets the root entries recorded in the log.

--- a/ModelBuilder/Model.cs
+++ b/ModelBuilder/Model.cs
@@ -1,6 +1,7 @@
 namespace ModelBuilder
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     ///     The <see cref="Model" /> class
@@ -11,6 +12,8 @@ namespace ModelBuilder
     public static partial class Model
     {
         private static readonly ModelBuilderRegistry _registry = new ModelBuilderRegistry();
+        private static readonly Dictionary<Type, Func<IBuildContext, object?>> _valueSourceFactories =
+            new Dictionary<Type, Func<IBuildContext, object?>>();
 
         /// <summary>
         ///     Creates a populated instance of the specified type.
@@ -23,18 +26,43 @@ namespace ModelBuilder
         {
             instanceType = instanceType ?? throw new ArgumentNullException(nameof(instanceType));
 
-            if (_registry.TryGet(instanceType, out var builder) == false
-                || builder is null)
-            {
-                throw NoBuilder(instanceType);
-            }
-
             var context = NewContext(null, null);
 
             using (context.EnterRoot(instanceType))
             {
-                return builder.Create(context);
+                if (_registry.TryGet(instanceType, out var builder) && builder != null)
+                {
+                    return builder.Create(context);
+                }
+
+                if (_valueSourceFactories.TryGetValue(instanceType, out var factory))
+                {
+                    return factory(context)!;
+                }
+
+                if (BuiltInValueSources.Default.TryCreateBoxed(instanceType, context, out var builtInValue))
+                {
+                    return builtInValue!;
+                }
             }
+
+            throw NoBuilder(instanceType);
+        }
+
+        /// <summary>
+        ///     Registers a value-source factory for a runtime type, so that <see cref="Create(Type)" />
+        ///     can resolve value-source-only roots (collections, enums, nullable wrappers) that have no
+        ///     generated class builder, without runtime reflection. Called by generated code; not
+        ///     typically called directly.
+        /// </summary>
+        /// <typeparam name="T">The type the value source produces.</typeparam>
+        /// <param name="source">The value source to register.</param>
+        /// <exception cref="ArgumentNullException">The <paramref name="source" /> parameter is <c>null</c>.</exception>
+        public static void RegisterValueSource<T>(IValueSource<T> source)
+        {
+            source = source ?? throw new ArgumentNullException(nameof(source));
+
+            _valueSourceFactories[typeof(T)] = context => source.Create(context, new BuildTarget(typeof(T), typeof(T).Name));
         }
 
         /// <summary>

--- a/ModelBuilder/NullBuildLog.cs
+++ b/ModelBuilder/NullBuildLog.cs
@@ -21,7 +21,8 @@ namespace ModelBuilder
             BuildLogEntryKind kind,
             Type targetType,
             string? memberName = null,
-            string? reason = null)
+            string? reason = null,
+            int? collectionIndex = null)
         {
             return _scope;
         }
@@ -31,7 +32,8 @@ namespace ModelBuilder
             BuildLogEntryKind kind,
             Type targetType,
             string? memberName = null,
-            string? reason = null)
+            string? reason = null,
+            int? collectionIndex = null)
         {
         }
 

--- a/ModelBuilder/NullableValueSource.cs
+++ b/ModelBuilder/NullableValueSource.cs
@@ -26,12 +26,40 @@ namespace ModelBuilder
                 return null;
             }
 
-            if (ctx.TryResolveValueSource<T>(out var inner) == false || inner == null)
+            if (ctx.TryResolveValueSource<T>(out var inner) && inner != null)
+            {
+                return inner.Create(ctx, in target);
+            }
+
+            // T has no registered value source (an ordinary user-defined struct such as a discovered
+            // class/struct builds through the generated ModelBuilderSlot<T> builder instead of a value
+            // source). Fall back to it so Nullable<T> members of a custom struct populate consistently
+            // with their non-nullable counterparts, instead of always resolving to null.
+            var builder = ModelBuilderSlot<T>.Instance;
+
+            if (builder == null)
             {
                 return null;
             }
 
-            return inner.Create(ctx, in target);
+            if (ctx.IsInBuildChain(typeof(T)))
+            {
+                ctx.Log.Write(BuildLogEntryKind.SkipMember, typeof(T), target.MemberName, "circular-reference guard");
+
+                return null;
+            }
+
+            if (ctx.IsDepthExceeded)
+            {
+                ctx.Log.Write(BuildLogEntryKind.SkipMember, typeof(T), target.MemberName, "depth guard");
+
+                return null;
+            }
+
+            using (ctx.EnterMember(typeof(T), target.MemberName ?? typeof(T).Name, typeof(T)))
+            {
+                return builder.Create(ctx);
+            }
         }
     }
 }

--- a/ModelBuilder/ValueSourceRegistry.cs
+++ b/ModelBuilder/ValueSourceRegistry.cs
@@ -13,6 +13,7 @@ namespace ModelBuilder
     internal sealed class ValueSourceRegistry
     {
         private readonly Dictionary<Type, object> _sources = new Dictionary<Type, object>();
+        private readonly Dictionary<Type, Func<IBuildContext, object?>> _boxedFactories = new Dictionary<Type, Func<IBuildContext, object?>>();
 
         /// <summary>
         ///     Registers a value source for the type it produces.
@@ -25,6 +26,7 @@ namespace ModelBuilder
             source = source ?? throw new ArgumentNullException(nameof(source));
 
             _sources[typeof(T)] = source;
+            _boxedFactories[typeof(T)] = context => source.Create(context, new BuildTarget(typeof(T), typeof(T).Name));
         }
 
         /// <summary>
@@ -43,6 +45,28 @@ namespace ModelBuilder
             }
 
             source = null;
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Attempts to create a value for a runtime <see cref="Type" /> using the value source
+        ///     registered for it, without requiring the type to be known at compile time.
+        /// </summary>
+        /// <param name="type">The type to create a value for.</param>
+        /// <param name="context">The build context for the current build.</param>
+        /// <param name="value">The created value, boxed when the type is a value type.</param>
+        /// <returns><c>true</c> if a value source is registered for <paramref name="type" />; otherwise, <c>false</c>.</returns>
+        internal bool TryCreateBoxed(Type type, IBuildContext context, out object? value)
+        {
+            if (_boxedFactories.TryGetValue(type, out var factory))
+            {
+                value = factory(context);
+
+                return true;
+            }
+
+            value = null;
 
             return false;
         }

--- a/README.md
+++ b/README.md
@@ -429,9 +429,10 @@ diagnostic**, not a runtime exception:
 
 | Diagnostic | Meaning |
 | --- | --- |
-| `MB1001` | The requested root type cannot have a builder generated (for example it is abstract, an interface, generic or has no accessible constructor). |
+| `MB1001` | The requested root type cannot have a builder generated (for example it is abstract, an interface, or has no accessible constructor — a supported collection shape such as `List<T>` or `Dictionary<K,V>` is buildable even though it's generic). |
 | `MB1002` | The root type is inaccessible (for example `private`) to the generated code. |
 | `MB1005` | A `Model.Create(typeof(X))` root could not be resolved to a buildable type. |
+| `MB1011` | The discovered collection is a shape ModelBuilder does not build (for example `ArraySegment<T>` or a live view like `Dictionary<K,V>.KeyCollection`). |
 
 ### GenerateModelBuilder
 

--- a/design.md
+++ b/design.md
@@ -947,10 +947,67 @@ extension point: a consumer adding several value sources around a shared data se
 source cache a chosen data item under a key and the others read it for coherent, related values.
 
 **Tier 4 — collections (structural, generator-emitted):**
-`T[]`, `List<T>`, `IList<T>`, `IReadOnlyList<T>`, `IEnumerable<T>`, `ICollection<T>`,
-`IReadOnlyCollection<T>`, `Dictionary<K,V>`, `IDictionary<K,V>`, `IReadOnlyDictionary<K,V>`,
-`HashSet<T>`, `ISet<T>` — built structurally from the element/key/value sources, with the
-`MinCount`/`MaxCount` controls (and the #188 `MaxCount`-without-`MinCount` validation).
+
+Every collection is built structurally from its element/key/value sources, honoring the
+`MinCount`/`MaxCount` controls (and the #188 `MaxCount`-without-`MinCount` validation). A build
+root, constructor parameter, or settable member of any of the following shapes gets a generated
+`IValueSource<T>` — no `Mapping<,>` or custom source required:
+
+| Materialized as | Interface targets that resolve to it |
+|---|---|
+| `T[]` | — |
+| `List<T>` | `IList<T>`, `ICollection<T>`, `IEnumerable<T>`, `IReadOnlyList<T>`, `IReadOnlyCollection<T>` |
+| `HashSet<T>` | `ISet<T>`, `IReadOnlySet<T>` |
+| `Dictionary<K,V>` | `IDictionary<K,V>`, `IReadOnlyDictionary<K,V>` |
+| `Collection<T>` | — |
+| `Queue<T>` | — |
+| `Stack<T>` | — |
+| `SortedSet<T>` | — |
+| `ObservableCollection<T>` | — |
+| `SortedDictionary<K,V>` | — |
+| `SortedList<K,V>` | — |
+| `ConcurrentDictionary<K,V>` | — |
+| `ConcurrentBag<T>` | — |
+| `ConcurrentQueue<T>` | — |
+| `ConcurrentStack<T>` | — |
+| `ReadOnlyCollection<T>` | — |
+| `ReadOnlyDictionary<K,V>` | — |
+| `ReadOnlyObservableCollection<T>` | — |
+| `ImmutableArray<T>` | — |
+| `ImmutableList<T>` | `IImmutableList<T>` |
+| `ImmutableHashSet<T>` | `IImmutableSet<T>` |
+| `ImmutableSortedSet<T>` | — |
+| `ImmutableDictionary<K,V>` | `IImmutableDictionary<K,V>` |
+| `ImmutableSortedDictionary<K,V>` | — |
+| `ImmutableQueue<T>` | `IImmutableQueue<T>` |
+| `ImmutableStack<T>` | `IImmutableStack<T>` |
+
+**Construction strategy per kind:**
+
+- **Array** builds directly into a `T[]` of the chosen count, one indexed `Build<T>` call per slot.
+- **Add-based** kinds (`List`, `HashSet`, `Collection`, `Queue`, `Stack`, `SortedSet`,
+  `ObservableCollection`, `ConcurrentBag`, `ConcurrentQueue`, `ConcurrentStack`) build the backing
+  type directly and call its natural mutator (`Add`/`Enqueue`/`Push`) once per item.
+- **Keyed** kinds (`Dictionary`, `SortedDictionary`, `SortedList`, `ConcurrentDictionary`) build the
+  backing type directly and assign `result[key] = value` per pair. `SortedDictionary`, `SortedList`,
+  and `ConcurrentDictionary` retry key generation (bounded at 10 attempts) when a generated key
+  collides with one already present, so a small key space does not silently under-populate the
+  collection; a colliding `Dictionary` key is skipped instead, unchanged from prior behavior. A
+  reference-typed key that comes back `null` is always skipped, never retried indefinitely.
+- **Read-only wrapper** kinds (`ReadOnlyCollection`, `ReadOnlyDictionary`, `ReadOnlyObservableCollection`)
+  build a mutable backing collection (`List<T>`/`Dictionary<K,V>`/`ObservableCollection<T>`) the same
+  way as their mutable counterparts, then wrap it in the read-only type — the only construction path
+  available, since these types have no public mutators of their own.
+- **Immutable** kinds build a mutable `List<T>`/`Dictionary<K,V>` backing collection the same way,
+  then call the matching `{ImmutableXxx}.CreateRange(backing)` factory method — immutable collections
+  have no mutators to call incrementally.
+
+**Unsupported collection shapes.** A small number of BCL collection-shaped types are intentionally
+excluded because they have no usable mutator or are a live view over another collection rather than
+an independently constructible value: `ArraySegment<T>`, `Dictionary<K,V>.KeyCollection`/
+`.ValueCollection`, and `SortedDictionary<K,V>.KeyCollection`/`.ValueCollection`. Discovering one of
+these as a build target raises `MB1011` instead of silently producing a null or empty value; add a
+`Mapping<,>` to a supported collection or register a custom `IValueSource<T>` to build it.
 
 **Explicitly out of scope — no built-in source (require a `Mapping<,>` or custom source):**
 `Stream` and other abstract IO, `Type`, `Task`/`Task<T>`, `Expression`, delegates, `object`,
@@ -1496,6 +1553,7 @@ runs. Indicative catalogue (IDs illustrative, severities tunable via `.editorcon
 | `MB1008` | Warning | A registered `IValueSource<T>` is never selected (dead registration) | "Remove the registration or widen its match; it currently matches no discovered member." |
 | `MB1009` | Info | A member falls back to runtime matching via `.When(...)` on a hot path | "Express the condition with `.ForMembersNamed/Matching(...)` to compile it in, if possible." |
 | `MB1010` | Error | A write-only or init-only member is targeted in a way that can't be satisfied (§7, #282) | "Remove the member from population, or provide it via constructor args." |
+| `MB1011` | Warning | A discovered collection is a shape ModelBuilder does not build (no mutator, or a live view) (§8.2) | "Add `Model.Mapping<,>` to a supported collection, or register a custom `IValueSource<{X}>`." |
 
 The generator also emits the **cycle** and **ambiguity** errors against the *merged* configuration
 for the whole compilation, so a conflict introduced by combining two modules is caught (§8.2.6).

--- a/design.md
+++ b/design.md
@@ -982,6 +982,18 @@ root, constructor parameter, or settable member of any of the following shapes g
 | `ImmutableQueue<T>` | `IImmutableQueue<T>` |
 | `ImmutableStack<T>` | `IImmutableStack<T>` |
 
+**User-defined collection types.** A concrete, accessible, non-abstract type with a public
+parameterless constructor that either derives from one of the mutable Add-based or keyed kinds
+above (for example `class WidgetBag : Collection<Widget>`) or implements `ICollection<T>` /
+`IDictionary<TKey, TValue>` directly (for example a hand-written `IList<T>` implementation) is
+classified with the matching shape and built as *itself* — constructed via its own parameterless
+constructor and populated through its own (inherited or implemented) mutator — rather than being
+discarded as an ordinary class with no settable members. This does not extend to the read-only
+wrapper or immutable kinds, since those have no usable parameterless constructor to build a
+subclass through. A type that doesn't qualify (abstract, no parameterless constructor, or matches
+no known shape) falls back to being populated as an ordinary class from its settable members, as
+before.
+
 **Construction strategy per kind:**
 
 - **Array** builds directly into a `T[]` of the chosen count, one indexed `Build<T>` call per slot.
@@ -998,6 +1010,7 @@ root, constructor parameter, or settable member of any of the following shapes g
   build a mutable backing collection (`List<T>`/`Dictionary<K,V>`/`ObservableCollection<T>`) the same
   way as their mutable counterparts, then wrap it in the read-only type — the only construction path
   available, since these types have no public mutators of their own.
+
 - **Immutable** kinds build a mutable `List<T>`/`Dictionary<K,V>` backing collection the same way,
   then call the matching `{ImmutableXxx}.CreateRange(backing)` factory method — immutable collections
   have no mutators to call incrementally.


### PR DESCRIPTION
## Summary

Fixes #397 — ModelBuilder v9 couldn't create instances of generic collection types as root types,
and collection properties with default initializers were being overwritten with `null` because no
builder/value source was generated for their type.

## Changes

- **Collection root/member support**: root-processing in `BuildGraphWalker.Walk` now tries
  `TryClassifyCollection` before the `IsBuildable` check, so a collection can be a build root
  (`Model.Create<List<T>>()`, `Model.Create(typeof(Dictionary<K,V>))`), not just a nested member.
- **Expanded `CollectionKind` coverage** from 6 to 24 kinds — `Collection<T>`, `Queue<T>`, `Stack<T>`,
  `SortedSet<T>`, `ObservableCollection<T>`, `SortedDictionary<K,V>`, `SortedList<K,V>`,
  `ConcurrentDictionary<K,V>`, `ConcurrentBag/Queue/Stack<T>`, `ReadOnlyCollection<T>`,
  `ReadOnlyDictionary<K,V>`, `ReadOnlyObservableCollection<T>`, and the `Immutable*` family, each with
  the construction strategy appropriate to its shape (add-based, keyed with bounded retry-on-collision,
  read-only wrapper over a mutable backing collection, or `Immutable*.CreateRange`).
- **`Model.Create(Type)` fallback**: the non-generic entry point now falls back through a registered
  value-source factory (new `Model.RegisterValueSource<T>()`, called by generated code) before giving
  up, so collection types resolve the same way as the generic `Model.Create<T>()` path.
- **New `MB1011` diagnostic** for collection-shaped types ModelBuilder intentionally doesn't build
  (`ArraySegment<T>`, `Dictionary<K,V>.KeyCollection`/`.ValueCollection`,
  `SortedDictionary<K,V>.KeyCollection`/`.ValueCollection`) instead of silently producing null/empty.
- **Logging/build-path fix**: collection-item builds now use `Log.BeginScope` instead of a flat
  `Log.Write`, so nested item builds nest correctly under their collection in the build log and
  exception build paths; a new `CollectionIndex` field on `BuildFrame`/`BuildLogEntry` gives structured
  access to an item's index alongside the existing `"item[i]"`/`"key[i]"`/`"value[i]"` naming.
- **Custom collection subclasses/interface implementers**: a concrete, accessible type with a public
  parameterless constructor that derives from a mutable collection base (e.g.
  `class WidgetBag : Collection<Widget>`) or implements `ICollection<T>`/`IDictionary<TKey,TValue>`
  directly is now built as itself via its own constructor and mutator, instead of falling through to
  ordinary (empty) class population.
- **Bug fix**: `Nullable<T>` members for user-defined structs (e.g. `PointStruct?`) were always built
  as `null` regardless of `NullPercentage` — `NullableValueSource<T>.Create` only checked the
  value-source/custom-source/registry tier and never fell back to `ModelBuilderSlot<T>`, which is
  where a discovered struct's generated builder actually lives. Fixed with the same
  `IsInBuildChain`/depth-guard/`EnterMember` pattern used by `BuildContext.BuildCore<T>`'s own fallback.
  Found via the new integration test suite (see below), not a regression introduced by this PR.
- **New `ModelBuilder.IntegrationTests` project** (`net472;net8.0;net9.0;net10.0`) — 41 end-to-end
  scenario tests restoring the kind of coverage v8 had (unit tests alone can't validate full build
  outcomes): construction, property population, structs, nullables, numeric boundaries, enums, every
  `CollectionKind`, custom collection types, circular references, mapping, ignoring, custom value
  sources, populate/post-build hooks, logging, tuning options, and failure handling.
- `design.md`'s Tier 4 (collections) section rewritten to document the full 24-kind BCL surface,
  interface-target table, per-kind construction strategy, unsupported shapes, and custom collection
  type support. `README.md`'s diagnostics table updated for `MB1011` and to stop implying all generic
  root types fail (a supported collection root is generic and now buildable).

## Testing

- `ModelBuilder.Generator.UnitTests`: 128/128 passed
- `ModelBuilder.UnitTests`: 340/340 passed
- `ModelBuilder.IntegrationTests` (new, 4 TFMs): 41/41 passed
- Full solution build: 0 warnings, 0 errors
- `dotnet test ModelBuilder.slnx`: 634/634 passed

## Related

- Follow-up gaps discovered during this work were filed as separate issues rather than folded in
  here: #398 (`[GenerateModelBuilder]` not implemented by the generator), #399 (open generic type
  mapping + further collection interface registrations), #400 (no diagnostic when a *member*, not a
  root, resolves to an unmapped interface/abstract type).
