### PR TITLE
Fix CS8619 nullable reference type mismatch for generic collection members

### DIFF
--- a/ModelBuilder.Generator.UnitTests/GeneratedExecutionTests.cs
+++ b/ModelBuilder.Generator.UnitTests/GeneratedExecutionTests.cs
@@ -4,6 +4,7 @@
     using System.Linq;
     using System.Reflection;
     using FluentAssertions;
+    using Microsoft.CodeAnalysis;
     using ModelBuilder;
     using Xunit;
 
@@ -819,6 +820,48 @@ namespace Sample
             var harness = GeneratorTestHarness.Run(source);
 
             harness.GeneratorDiagnostics.Should().Contain(d => d.Id == "MB1011");
+        }
+
+        [Fact]
+        public void CreateBuildsNullableReferenceTypeMembersWithoutNullabilityMismatch()
+        {
+            // Regression test for a generic invariant container (List<T>) with a nullable-reference-
+            // annotated type argument (object?): the generated code must format the typeof() argument
+            // without the top-level "?" (CS8639) while still using the fully nullable-annotated type for
+            // Build<T>()/EqualityComparer<T>/default(T), otherwise the generic argument mismatches
+            // between "List<object>" and "List<object?>" trigger CS8619.
+            const string source = @"
+namespace Sample
+{
+    public sealed class Bucket
+    {
+        public object? State { get; set; }
+        public System.Collections.Generic.List<object?>? Items { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Bucket Build() => global::ModelBuilder.Model.Create<Bucket>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationDiagnostics
+                .Where(d => d.Severity is DiagnosticSeverity.Error or DiagnosticSeverity.Warning)
+                .Should()
+                .BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var bucketType = assembly.GetType("Sample.Bucket", throwOnError: true)!;
+
+            // Plain `object`/`object?` has no registered value source, so building it legitimately
+            // yields null; the point of this test is that generation and compilation succeed without
+            // CS8619/CS8639, and that the collection member itself (not its unresolvable elements) is
+            // populated.
+            var bucket = CreateViaModel(bucketType);
+
+            var items = (System.Collections.IEnumerable)bucketType.GetProperty("Items")!.GetValue(bucket)!;
+            items.Should().NotBeNull();
         }
 
         [Fact]

--- a/ModelBuilder.Generator.UnitTests/MemberModelTests.cs
+++ b/ModelBuilder.Generator.UnitTests/MemberModelTests.cs
@@ -41,6 +41,15 @@ namespace ModelBuilder.Generator.UnitTests
         }
 
         [Fact]
+        public void EqualsReturnsFalseForDifferentRuntimeTypeName()
+        {
+            var first = new MemberModel("Name", "System.String", runtimeTypeName: "System.String");
+            var second = new MemberModel("Name", "System.String", runtimeTypeName: "System.Object");
+
+            first.Equals(second).Should().BeFalse();
+        }
+
+        [Fact]
         public void EqualsReturnsFalseForDifferentTypeName()
         {
             var first = new MemberModel("Name", "System.String");
@@ -75,6 +84,26 @@ namespace ModelBuilder.Generator.UnitTests
             sut.Name.Should().Be("Name");
             sut.TypeName.Should().Be("System.String");
             sut.DefaultLiteral.Should().Be("default");
+        }
+
+        [Fact]
+        public void RuntimeTypeNameDefaultsToTypeNameWhenNotSpecified()
+        {
+            var sut = new MemberModel("Name", "System.Collections.Generic.List<object?>?");
+
+            sut.RuntimeTypeName.Should().Be("System.Collections.Generic.List<object?>?");
+        }
+
+        [Fact]
+        public void RuntimeTypeNameReturnsExplicitValueWhenSpecified()
+        {
+            var sut = new MemberModel(
+                "Name",
+                "System.Collections.Generic.List<object?>?",
+                runtimeTypeName: "System.Collections.Generic.List<object?>");
+
+            sut.RuntimeTypeName.Should().Be("System.Collections.Generic.List<object?>");
+            sut.TypeName.Should().Be("System.Collections.Generic.List<object?>?");
         }
     }
 }

--- a/ModelBuilder.Generator/BuildGraphWalker.cs
+++ b/ModelBuilder.Generator/BuildGraphWalker.cs
@@ -15,12 +15,43 @@ namespace ModelBuilder.Generator
     /// </summary>
     internal static class BuildGraphWalker
     {
+        // Adds the "?" nullable-reference-type modifier (e.g. "object?", "List<object?>") on top of the
+        // default fully-qualified format, so generic type arguments used in generated code (Build<T>(),
+        // EqualityComparer<T>, default(T)) match the member/parameter's actual declared nullability and
+        // don't trigger CS8619 ("Nullability of reference types in value of type X doesn't match target
+        // type Y") for reference-typed members/elements that are declared nullable.
+        private static readonly SymbolDisplayFormat _nullableAwareFormat =
+            SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
+                SymbolDisplayFormat.FullyQualifiedFormat.MiscellaneousOptions
+                | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
+
         /// <summary>
         ///     Determines whether the type has a public constructor the generated code can call.
         /// </summary>
         public static bool HasAccessibleConstructor(INamedTypeSymbol type)
         {
             return SelectConstructor(type) != null;
+        }
+
+        /// <summary>
+        ///     Renders a type name preserving nullable reference annotations (including nested ones, for
+        ///     example <c>List&lt;object?&gt;</c>), for use as a generic type argument.
+        /// </summary>
+        private static string FormatTypeName(ITypeSymbol type)
+        {
+            return type.ToDisplayString(_nullableAwareFormat);
+        }
+
+        /// <summary>
+        ///     Renders a type name suitable for a <c>typeof(...)</c> expression: nested nullable
+        ///     annotations are preserved (for example <c>List&lt;object?&gt;</c>), but a top-level
+        ///     nullable reference annotation is stripped, since <c>typeof</c> rejects it with CS8639.
+        /// </summary>
+        private static string FormatRuntimeTypeName(ITypeSymbol type)
+        {
+            var notAnnotated = type.WithNullableAnnotation(NullableAnnotation.NotAnnotated);
+
+            return notAnnotated.ToDisplayString(_nullableAwareFormat);
         }
 
         public static GenerationModel Walk(IEnumerable<INamedTypeSymbol> roots)
@@ -56,7 +87,9 @@ namespace ModelBuilder.Generator
 
                 if (TryClassifyCollection(type, out _, out var rootElement, out var rootValue, unsupported))
                 {
-                    collections[type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)] = type;
+                    var rootSlotName = FormatRuntimeTypeName(type);
+
+                    collections[rootSlotName] = type;
 
                     if (rootElement != null)
                     {
@@ -154,12 +187,15 @@ namespace ModelBuilder.Generator
             var retryOnKeyCollision = _retryOnKeyCollisionKinds.Contains(kind);
             var isCustomType = IsCustomCollectionType(type);
 
+            var elementTypeName = element != null ? FormatTypeName(element) : string.Empty;
+            var valueTypeName = value != null ? FormatTypeName(value) : string.Empty;
+
             return new CollectionModel(
                 kind,
                 slotType,
                 CreateName(slotType, "ValueSource", sourceNames),
-                element?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty,
-                value?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) ?? string.Empty,
+                elementTypeName,
+                valueTypeName,
                 keyCanBeNull,
                 retryOnKeyCollision,
                 isCustomType);
@@ -237,7 +273,9 @@ namespace ModelBuilder.Generator
             {
                 if (array.Rank == 1)
                 {
-                    collections[type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)] = type;
+                    var arraySlotName = FormatRuntimeTypeName(type);
+
+                    collections[arraySlotName] = type;
 
                     Visit(array.ElementType, queue, seen, nullables, collections, unsupported);
                 }
@@ -264,7 +302,9 @@ namespace ModelBuilder.Generator
 
             if (TryClassifyCollection(named, out _, out var element, out var value, unsupported))
             {
-                collections[named.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)] = named;
+                var namedSlotName = FormatRuntimeTypeName(named);
+
+                collections[namedSlotName] = named;
 
                 if (element != null)
                 {
@@ -733,8 +773,9 @@ namespace ModelBuilder.Generator
                     ctorParameters.Add(
                         new MemberModel(
                             parameter.Name,
-                            parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                            FormatDefaultLiteral(parameter)));
+                            FormatTypeName(parameter.Type),
+                            FormatDefaultLiteral(parameter),
+                            FormatRuntimeTypeName(parameter.Type)));
                 }
             }
 
@@ -745,7 +786,8 @@ namespace ModelBuilder.Generator
                 members.Add(
                     new MemberModel(
                         property.Name,
-                        property.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)));
+                        FormatTypeName(property.Type),
+                        runtimeTypeName: FormatRuntimeTypeName(property.Type)));
             }
 
             var allConstructors = ImmutableArray.CreateBuilder<ConstructorModel>();
@@ -764,8 +806,9 @@ namespace ModelBuilder.Generator
                     parameters.Add(
                         new MemberModel(
                             parameter.Name,
-                            parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat),
-                            FormatDefaultLiteral(parameter)));
+                            FormatTypeName(parameter.Type),
+                            FormatDefaultLiteral(parameter),
+                            FormatRuntimeTypeName(parameter.Type)));
                 }
 
                 allConstructors.Add(

--- a/ModelBuilder.Generator/MemberModel.cs
+++ b/ModelBuilder.Generator/MemberModel.cs
@@ -8,18 +8,20 @@ namespace ModelBuilder.Generator
     /// </summary>
     internal readonly struct MemberModel : IEquatable<MemberModel>
     {
-        public MemberModel(string name, string typeName, string? defaultLiteral = null)
+        public MemberModel(string name, string typeName, string? defaultLiteral = null, string? runtimeTypeName = null)
         {
             Name = name;
             TypeName = typeName;
             DefaultLiteral = defaultLiteral;
+            RuntimeTypeName = runtimeTypeName ?? typeName;
         }
 
         public bool Equals(MemberModel other)
         {
             return string.Equals(Name, other.Name, StringComparison.Ordinal)
                    && string.Equals(TypeName, other.TypeName, StringComparison.Ordinal)
-                   && string.Equals(DefaultLiteral, other.DefaultLiteral, StringComparison.Ordinal);
+                   && string.Equals(DefaultLiteral, other.DefaultLiteral, StringComparison.Ordinal)
+                   && string.Equals(RuntimeTypeName, other.RuntimeTypeName, StringComparison.Ordinal);
         }
 
         public override bool Equals(object? obj)
@@ -35,6 +37,7 @@ namespace ModelBuilder.Generator
                            ^ StringComparer.Ordinal.GetHashCode(TypeName);
 
                 hash = hash * 397 ^ (DefaultLiteral == null ? 0 : StringComparer.Ordinal.GetHashCode(DefaultLiteral));
+                hash = hash * 397 ^ StringComparer.Ordinal.GetHashCode(RuntimeTypeName);
 
                 return hash;
             }
@@ -43,6 +46,14 @@ namespace ModelBuilder.Generator
         public string? DefaultLiteral { get; }
 
         public string Name { get; }
+
+        /// <summary>
+        ///     Gets the type name to use inside a <c>typeof(...)</c> expression. This strips any
+        ///     top-level nullable reference annotation from <see cref="TypeName" /> (which <c>typeof</c>
+        ///     rejects with CS8639) while preserving nested annotations, for example
+        ///     <c>List&lt;object?&gt;</c> stays as-is but <c>object?</c> becomes <c>object</c>.
+        /// </summary>
+        public string RuntimeTypeName { get; }
 
         public string TypeName { get; }
     }

--- a/ModelBuilder.Generator/SourceEmitter.cs
+++ b/ModelBuilder.Generator/SourceEmitter.cs
@@ -510,7 +510,7 @@ namespace ModelBuilder.Generator
 
             foreach (var member in model.Members)
             {
-                builder.Append(Indent).AppendLine($"            if (context.ShouldPopulate(typeof({type}), \"{member.Name}\", typeof({member.TypeName})))");
+                builder.Append(Indent).AppendLine($"            if (context.ShouldPopulate(typeof({type}), \"{member.Name}\", typeof({member.RuntimeTypeName})))");
                 builder.Append(Indent).AppendLine("            {");
                 builder.Append(Indent).AppendLine($"                if (context.RetainAssignedValues == false || global::System.Collections.Generic.EqualityComparer<{member.TypeName}>.Default.Equals(instance.{member.Name}!, default({member.TypeName})!))");
                 builder.Append(Indent).AppendLine("                {");
@@ -555,7 +555,7 @@ namespace ModelBuilder.Generator
                     continue;
                 }
 
-                builder.Append(indent).AppendLine($"if (context.ShouldPopulate(typeof({type}), \"{member.Name}\", typeof({member.TypeName})))");
+                builder.Append(indent).AppendLine($"if (context.ShouldPopulate(typeof({type}), \"{member.Name}\", typeof({member.RuntimeTypeName})))");
                 builder.Append(indent).AppendLine("{");
                 builder.Append(indent).Append(Indent).AppendLine($"if (context.RetainAssignedValues == false || global::System.Collections.Generic.EqualityComparer<{member.TypeName}>.Default.Equals(instance.{member.Name}!, default({member.TypeName})!))");
                 builder.Append(indent).Append(Indent).AppendLine("{");
@@ -572,8 +572,12 @@ namespace ModelBuilder.Generator
             {
                 var parameter = ctorParameters[index];
 
+                // Compare using RuntimeTypeName (top-level nullable annotation stripped) rather than
+                // TypeName, so a settable property that differs from its matching constructor parameter
+                // only in top-level nullability (for example ctor parameter `string currency` and
+                // property `string? Currency`) still matches.
                 if (string.Equals(parameter.Name, member.Name, StringComparison.OrdinalIgnoreCase)
-                    && string.Equals(parameter.TypeName, member.TypeName, StringComparison.Ordinal))
+                    && string.Equals(parameter.RuntimeTypeName, member.RuntimeTypeName, StringComparison.Ordinal))
                 {
                     return index;
                 }


### PR DESCRIPTION
Fixes #402

## Problem

`BuildGraphWalker` formatted member, constructor parameter, and collection type names via `ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)` without `IncludeNullableReferenceTypeModifier`, silently dropping nullable-reference annotations (e.g. `object?` → `object`, `List<object?>` → `List<object>`). A generic invariant container with a nullable-annotated type argument (e.g. a `List<object?>` member) then generated `context.Build<List<object>>(...)`, which mismatches the declared `List<object?>?` member and triggers CS8619.

## Fix

- `BuildGraphWalker` gains a nullable-aware `SymbolDisplayFormat` and two helpers:
  - `FormatTypeName` — full nullable annotations (nested and top-level), used for `Build<T>()`/`EqualityComparer<T>`/`default(T)`.
  - `FormatRuntimeTypeName` — strips only the *top-level* nullable annotation, used for `typeof(...)` (which rejects a top-level `?` with CS8639 but allows nested ones, e.g. `typeof(List<object?>)` compiles).
- `MemberModel` gains a `RuntimeTypeName` field (defaults to `TypeName` when not specified), used only for `typeof(...)` sites in `SourceEmitter`.
- Collection dictionary keys and `CollectionModel.SlotType` also use `FormatRuntimeTypeName`, since a collection's generated `IValueSource<T>.Create()` return type and internal construction must agree on nullability to avoid a second CS8619 inside the value-source class itself.
- Fixed a regression this change surfaced: `SourceEmitter.MatchingParameterIndex` (matches a settable property to an already-supplied constructor parameter) compared `TypeName` by exact string, which broke once `TypeName` became nullable-annotation-aware (e.g. `string currency` no longer matched `string? Currency`). Now compares `RuntimeTypeName` instead, so constructor-supplied values are no longer silently overwritten.

## Testing

- New test: `CreateBuildsNullableReferenceTypeMembersWithoutNullabilityMismatch` (asserts zero compilation errors/warnings for a type with `object?` and `List<object?>?` members).
- New `MemberModelTests` facts covering `RuntimeTypeName` default/explicit/equality behavior.
- Full solution build: 0 warnings, 0 errors. Full test suite: 1658/1658 passing.
