### PR TITLE
v9: Support open generic type mapping and expand collection interface registrations (#399)

### DIFF
--- a/ModelBuilder.Generator.UnitTests/GeneratedExecutionTests.cs
+++ b/ModelBuilder.Generator.UnitTests/GeneratedExecutionTests.cs
@@ -311,6 +311,200 @@ namespace Sample
         }
 
         [Fact]
+        public void CreateBuildsClosedUserDefinedGenericTypeAsRoot()
+        {
+            const string source = @"
+namespace Sample
+{
+    public sealed class Box<T>
+    {
+        public T? Value { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Box<int> Build() => global::ModelBuilder.Model.Create<Box<int>>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var callerType = assembly.GetType("Sample.Caller", throwOnError: true)!;
+            var boxType = assembly.GetType("Sample.Box`1", throwOnError: true)!;
+            var closedBoxType = boxType.MakeGenericType(typeof(int));
+
+            var box = callerType.GetMethod("Build")!.Invoke(null, null)!;
+
+            closedBoxType.GetProperty("Value")!.GetValue(box).Should().NotBe(0);
+        }
+
+        [Fact]
+        public void CreateBuildsClosedUserDefinedGenericTypeAsMember()
+        {
+            const string source = @"
+namespace Sample
+{
+    public sealed class Box<T>
+    {
+        public T? Value { get; set; }
+    }
+
+    public sealed class Widget
+    {
+        public int Id { get; set; }
+    }
+
+    public sealed class Holder
+    {
+        public Box<Widget>? Item { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Holder Build() => global::ModelBuilder.Model.Create<Holder>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
+            var boxType = assembly.GetType("Sample.Box`1", throwOnError: true)!;
+            var widgetType = assembly.GetType("Sample.Widget", throwOnError: true)!;
+            var closedBoxType = boxType.MakeGenericType(widgetType);
+
+            var holder = CreateViaModel(holderType);
+
+            var item = holderType.GetProperty("Item")!.GetValue(holder);
+
+            item.Should().NotBeNull();
+            item!.GetType().Should().Be(closedBoxType);
+        }
+
+        [Fact]
+        public void OpenGenericMappingBuildsClosedTargetWhenClosedShapeIsDeclared()
+        {
+            const string source = @"
+namespace Sample
+{
+    public interface IRepository<T>
+    {
+        T? Item { get; set; }
+    }
+
+    public sealed class Repository<T> : IRepository<T>
+    {
+        public T? Item { get; set; }
+    }
+
+    public sealed class Widget
+    {
+        public int Value { get; set; }
+    }
+
+    public sealed class Holder
+    {
+        public IRepository<Widget>? Repo { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Holder Build() =>
+            global::ModelBuilder.Model.Mapping(typeof(IRepository<>), typeof(Repository<>))
+                .Mapping<IRepository<Widget>, Repository<Widget>>()
+                .Create<Holder>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+            harness.GeneratorDiagnostics.Should().NotContain(d => d.Id == "MB1006" || d.Id == "MB1007");
+
+            var assembly = harness.EmitAndLoad();
+            var holderType = assembly.GetType("Sample.Holder", throwOnError: true)!;
+            var repositoryType = assembly.GetType("Sample.Repository`1", throwOnError: true)!;
+            var widgetType = assembly.GetType("Sample.Widget", throwOnError: true)!;
+            var closedRepositoryType = repositoryType.MakeGenericType(widgetType);
+
+            ValueSource<int>.Instance = new SequentialInt32Source();
+
+            try
+            {
+                var callerType = assembly.GetType("Sample.Caller", throwOnError: true)!;
+                var holder = callerType.GetMethod("Build")!.Invoke(null, null)!;
+
+                var repo = holderType.GetProperty("Repo")!.GetValue(holder);
+
+                repo.Should().NotBeNull();
+                repo!.GetType().Should().Be(closedRepositoryType);
+            }
+            finally
+            {
+                ValueSource<int>.Instance = null;
+            }
+        }
+
+        [Fact]
+        public void OpenGenericMappingWithNoAccessibleConstructorReportsDiagnostic()
+        {
+            const string source = @"
+namespace Sample
+{
+    public interface IRepository<T>
+    {
+    }
+
+    public sealed class Repository<T> : IRepository<T>
+    {
+        private Repository()
+        {
+        }
+    }
+
+    public static class Caller
+    {
+        public static void Configure() =>
+            global::ModelBuilder.Model.Mapping(typeof(IRepository<>), typeof(Repository<>));
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            harness.GeneratorDiagnostics.Should().Contain(d => d.Id == "MB1006");
+        }
+
+        [Fact]
+        public void OpenGenericMappingNeverUsedInClosedFormReportsDiagnostic()
+        {
+            const string source = @"
+namespace Sample
+{
+    public interface IRepository<T>
+    {
+    }
+
+    public sealed class Repository<T> : IRepository<T>
+    {
+    }
+
+    public static class Caller
+    {
+        public static void Configure() =>
+            global::ModelBuilder.Model.Mapping(typeof(IRepository<>), typeof(Repository<>));
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            harness.GeneratorDiagnostics.Should().Contain(d => d.Id == "MB1007");
+        }
+
+        [Fact]
         public void CreateTerminatesOnSelfReferencingType()
         {
             const string source = @"
@@ -584,6 +778,50 @@ namespace Sample
 
                     enumerable.Cast<object>().Should().NotBeEmpty($"{property.Name} should contain items");
                 }
+            }
+            finally
+            {
+                ValueSource<int>.Instance = null;
+            }
+        }
+
+        [Fact]
+        public void CreateBuildsConcurrentBagForIProducerConsumerCollectionMember()
+        {
+            const string source = @"
+namespace Sample
+{
+    public sealed class Bag
+    {
+        public System.Collections.Concurrent.IProducerConsumerCollection<int> Items { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Bag Build() => global::ModelBuilder.Model.Create<Bag>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+            harness.CompilationErrors.Should().BeEmpty();
+
+            var assembly = harness.EmitAndLoad();
+            var bagType = assembly.GetType("Sample.Bag", throwOnError: true)!;
+
+            ValueSource<int>.Instance = new SequentialInt32Source();
+
+            try
+            {
+                var bag = CreateViaModel(bagType);
+
+                var items = bagType.GetProperty("Items")!.GetValue(bag);
+
+                items.Should().NotBeNull();
+                items.Should().BeOfType<System.Collections.Concurrent.ConcurrentBag<int>>();
+
+                var enumerable = (System.Collections.IEnumerable)items!;
+
+                enumerable.Cast<object>().Should().NotBeEmpty();
             }
             finally
             {

--- a/ModelBuilder.Generator/AnalyzerReleases.Unshipped.md
+++ b/ModelBuilder.Generator/AnalyzerReleases.Unshipped.md
@@ -8,4 +8,6 @@ Rule ID | Category | Severity | Notes
 MB1001  | ModelBuilder | Warning | Abstract or interface build root has no mapping
 MB1002  | ModelBuilder | Warning | Build root has no accessible constructor
 MB1005  | ModelBuilder | Warning | Model.Create(typeof(X)) names a type that cannot be built
+MB1006  | ModelBuilder | Warning | Open generic mapping target has no accessible constructor
+MB1007  | ModelBuilder | Warning | Open generic mapping is never used in closed form
 MB1011  | ModelBuilder | Warning | Discovered collection shape is not supported

--- a/ModelBuilder.Generator/BuildGraphWalker.cs
+++ b/ModelBuilder.Generator/BuildGraphWalker.cs
@@ -461,6 +461,12 @@ namespace ModelBuilder.Generator
 
                     return true;
                 case "System.Collections.Concurrent.ConcurrentBag<T>":
+                // IProducerConsumerCollection<T> is implemented by ConcurrentBag<T>, ConcurrentQueue<T>
+                // and ConcurrentStack<T> alike (a genuine 3-way ambiguity), so it needs its own explicit
+                // default rather than being derived automatically from an interface walk. ConcurrentBag
+                // is chosen to match how ImmutableHashSet already "wins" IImmutableSet over
+                // ImmutableSortedSet.
+                case "System.Collections.Concurrent.IProducerConsumerCollection<T>":
                     kind = CollectionKind.ConcurrentBag;
                     element = args[0];
 
@@ -977,8 +983,22 @@ namespace ModelBuilder.Generator
                 return false;
             }
 
-            if (type.IsAbstract || type.IsStatic || type.IsGenericType)
+            if (type.IsAbstract || type.IsStatic)
             {
+                return false;
+            }
+
+            if (type.IsUnboundGenericType)
+            {
+                return false;
+            }
+
+            if (type.IsGenericType && IsClosedConstructedType(type) == false)
+            {
+                // An open generic type (still carrying its own type parameters, e.g. reached via
+                // an open Model.Mapping(typeof(X<>), typeof(Y<>)) declaration) has nothing concrete
+                // to construct. A fully closed generic (e.g. Repository<Widget>) is buildable like
+                // any other class/struct.
                 return false;
             }
 
@@ -1006,6 +1026,24 @@ namespace ModelBuilder.Generator
             }
 
             return SelectConstructor(type) != null;
+        }
+
+        private static bool IsClosedConstructedType(INamedTypeSymbol type)
+        {
+            foreach (var argument in type.TypeArguments)
+            {
+                if (argument.TypeKind == TypeKind.TypeParameter)
+                {
+                    return false;
+                }
+
+                if (argument is INamedTypeSymbol { IsGenericType: true } nested && IsClosedConstructedType(nested) == false)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static IMethodSymbol? SelectConstructor(INamedTypeSymbol type)

--- a/ModelBuilder.Generator/DiagnosticDescriptors.cs
+++ b/ModelBuilder.Generator/DiagnosticDescriptors.cs
@@ -45,5 +45,23 @@ namespace ModelBuilder.Generator
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             helpLinkUri: "https://github.com/roryprimrose/ModelBuilder");
+
+        public static readonly DiagnosticDescriptor OpenMappingTargetNoAccessibleConstructor = new DiagnosticDescriptor(
+            "MB1006",
+            "Open generic mapping target has no accessible constructor",
+            "'{0}' has no public constructor accessible to the generated code, so no builder can ever be generated for a closed shape of the '{1}' mapping. Add a public constructor or expose an accessible one.",
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: "https://github.com/roryprimrose/ModelBuilder");
+
+        public static readonly DiagnosticDescriptor OpenMappingNeverUsedInClosedForm = new DiagnosticDescriptor(
+            "MB1007",
+            "Open generic mapping is never used in closed form",
+            "'{0}' has an open generic mapping registered, but no closed Model.Mapping<,>() call declares a shape to build, so no builder will ever be generated for it. Add Model.Mapping<TClosedSource, TClosedTarget>() for each closed shape you need built.",
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: "https://github.com/roryprimrose/ModelBuilder");
     }
 }

--- a/ModelBuilder.Generator/ModelBuilderGenerator.cs
+++ b/ModelBuilder.Generator/ModelBuilderGenerator.cs
@@ -27,7 +27,7 @@ namespace ModelBuilder.Generator
                 .CreateSyntaxProvider(
                     static (node, _) => IsCandidateInvocation(node),
                     static (ctx, token) => GetRootType(ctx, token))
-                .Where(static capture => capture.Symbol is not null)
+                .Where(static capture => capture.Symbol is not null || capture.IsOpenMappingDeclaration)
                 .Select(static (capture, _) => capture);
 
             var attributeRoots = context.SyntaxProvider
@@ -69,15 +69,29 @@ namespace ModelBuilder.Generator
             var distinct = new Dictionary<string, INamedTypeSymbol>();
             var constructionTypeNames = new List<string>();
             var seenRequests = new HashSet<string>();
+            var closedMappingSourceDefinitions = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+            var openMappingDeclarations = new List<RootCapture>();
 
             foreach (var capture in captures)
             {
+                if (capture.IsOpenMappingDeclaration)
+                {
+                    openMappingDeclarations.Add(capture);
+
+                    continue;
+                }
+
                 if (capture.Symbol is null)
                 {
                     continue;
                 }
 
                 ReportRootDiagnostics(context, capture);
+
+                if (capture.MappingSourceDefinition is not null)
+                {
+                    closedMappingSourceDefinitions.Add(capture.MappingSourceDefinition);
+                }
 
                 var typeName = capture.Symbol.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
 
@@ -87,6 +101,11 @@ namespace ModelBuilder.Generator
                 {
                     constructionTypeNames.Add(typeName);
                 }
+            }
+
+            foreach (var declaration in openMappingDeclarations)
+            {
+                ReportOpenMappingDiagnostics(context, declaration, closedMappingSourceDefinitions);
             }
 
             if (distinct.Count == 0)
@@ -110,6 +129,35 @@ namespace ModelBuilder.Generator
             context.AddSource(
                 "ModelBuilderGenerated.g.cs",
                 SourceEmitter.Emit(models, constructionTypeNames, hasModuleInitializer));
+        }
+
+        private static void ReportOpenMappingDiagnostics(
+            SourceProductionContext context,
+            RootCapture declaration,
+            HashSet<INamedTypeSymbol> closedMappingSourceDefinitions)
+        {
+            var source = declaration.OpenMappingSource!;
+            var target = declaration.OpenMappingTarget!;
+            var location = declaration.Location ?? Location.None;
+
+            if (BuildGraphWalker.HasAccessibleConstructor(target) == false)
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        DiagnosticDescriptors.OpenMappingTargetNoAccessibleConstructor,
+                        location,
+                        target.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat),
+                        source.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+            }
+
+            if (closedMappingSourceDefinitions.Contains(source) == false)
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(
+                        DiagnosticDescriptors.OpenMappingNeverUsedInClosedForm,
+                        location,
+                        source.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat)));
+            }
         }
 
         private static void ReportRootDiagnostics(SourceProductionContext context, RootCapture capture)
@@ -180,13 +228,46 @@ namespace ModelBuilder.Generator
 
             if (method.Name == "Mapping")
             {
-                // Model.Mapping<TSource, TTarget>() makes the concrete TTarget a build root.
-                if (method.TypeArguments.Length != 2)
+                if (method.TypeArguments.Length == 2)
                 {
-                    return default;
+                    // Model.Mapping<TSource, TTarget>() makes the concrete TTarget a build root.
+                    var closedSourceDefinition = (method.TypeArguments[0] as INamedTypeSymbol)?.OriginalDefinition;
+
+                    return new RootCapture(
+                        method.TypeArguments[1] as INamedTypeSymbol,
+                        invocation.GetLocation(),
+                        mappingSourceDefinition: closedSourceDefinition);
                 }
 
-                return new RootCapture(method.TypeArguments[1] as INamedTypeSymbol, invocation.GetLocation());
+                if (method.TypeArguments.Length == 0
+                    && TryGetTypeOfArgument(invocation, context.SemanticModel, token, 0, out var mappingSourceType)
+                    && TryGetTypeOfArgument(invocation, context.SemanticModel, token, 1, out var mappingTargetType))
+                {
+                    // Model.Mapping(typeof(TSource), typeof(TTarget)) - the Type-based overload. Both
+                    // arguments must agree on being open (an open generic mapping declaration, validated
+                    // and cross-referenced against closed Mapping<,> usages rather than walked as a root)
+                    // or both closed (behaves exactly like the generic Mapping<TSource, TTarget>() overload).
+                    if (mappingSourceType!.IsUnboundGenericType && mappingTargetType!.IsUnboundGenericType)
+                    {
+                        // Normalize the unbound generic type symbols from typeof(X<>) to their original
+                        // definitions - the same representation used for the closed side below - so
+                        // constructor lookups and cross-referencing are accurate and symbol-comparable.
+                        return new RootCapture(
+                            mappingSourceType.OriginalDefinition,
+                            mappingTargetType.OriginalDefinition,
+                            invocation.GetLocation());
+                    }
+
+                    if (mappingSourceType.IsUnboundGenericType == false && mappingTargetType!.IsUnboundGenericType == false)
+                    {
+                        return new RootCapture(
+                            mappingTargetType,
+                            invocation.GetLocation(),
+                            mappingSourceDefinition: mappingSourceType.OriginalDefinition);
+                    }
+                }
+
+                return default;
             }
 
             if (method.Name == "Construct")
@@ -213,7 +294,7 @@ namespace ModelBuilder.Generator
                 // Non-generic Model.Create(typeof(X)) - the typeof constant names a build root (s6.2.1).
                 if (method.Name == "Create"
                     && containingType == ModelTypeName
-                    && TryGetTypeOfArgument(invocation, context.SemanticModel, token, out var constantType))
+                    && TryGetTypeOfArgument(invocation, context.SemanticModel, token, 0, out var constantType))
                 {
                     return new RootCapture(constantType, invocation.GetLocation(), isTypeOfRoot: true);
                 }
@@ -228,15 +309,17 @@ namespace ModelBuilder.Generator
             InvocationExpressionSyntax invocation,
             SemanticModel semanticModel,
             CancellationToken token,
+            int argumentIndex,
             out INamedTypeSymbol? type)
         {
             type = null;
 
-            var firstArgument = invocation.ArgumentList.Arguments.Count > 0
-                ? invocation.ArgumentList.Arguments[0].Expression
-                : null;
+            if (invocation.ArgumentList.Arguments.Count <= argumentIndex)
+            {
+                return false;
+            }
 
-            if (firstArgument is not TypeOfExpressionSyntax typeOf)
+            if (invocation.ArgumentList.Arguments[argumentIndex].Expression is not TypeOfExpressionSyntax typeOf)
             {
                 return false;
             }
@@ -307,19 +390,48 @@ namespace ModelBuilder.Generator
 
         private readonly struct RootCapture
         {
-            public RootCapture(INamedTypeSymbol? symbol, Location location, bool isTypeOfRoot = false, bool isConstructRoot = false)
+            public RootCapture(
+                INamedTypeSymbol? symbol,
+                Location location,
+                bool isTypeOfRoot = false,
+                bool isConstructRoot = false,
+                INamedTypeSymbol? mappingSourceDefinition = null)
             {
                 Symbol = symbol;
                 Location = location;
                 IsTypeOfRoot = isTypeOfRoot;
                 IsConstructRoot = isConstructRoot;
+                MappingSourceDefinition = mappingSourceDefinition;
+                IsOpenMappingDeclaration = false;
+                OpenMappingSource = null;
+                OpenMappingTarget = null;
+            }
+
+            public RootCapture(INamedTypeSymbol openSource, INamedTypeSymbol openTarget, Location location)
+            {
+                Symbol = null;
+                Location = location;
+                IsTypeOfRoot = false;
+                IsConstructRoot = false;
+                MappingSourceDefinition = null;
+                IsOpenMappingDeclaration = true;
+                OpenMappingSource = openSource;
+                OpenMappingTarget = openTarget;
             }
 
             public bool IsConstructRoot { get; }
 
+            public bool IsOpenMappingDeclaration { get; }
+
             public bool IsTypeOfRoot { get; }
 
             public Location? Location { get; }
+
+            public INamedTypeSymbol? MappingSourceDefinition { get; }
+
+            public INamedTypeSymbol? OpenMappingSource { get; }
+
+            public INamedTypeSymbol? OpenMappingTarget { get; }
 
             public INamedTypeSymbol? Symbol { get; }
         }

--- a/ModelBuilder.IntegrationTests/CollectionTests.cs
+++ b/ModelBuilder.IntegrationTests/CollectionTests.cs
@@ -33,6 +33,8 @@ namespace ModelBuilder.IntegrationTests
             actual.ConcurrentBagItems.Should().HaveCount(3);
             actual.ConcurrentQueueItems.Should().HaveCount(3);
             actual.ConcurrentStackItems.Should().HaveCount(3);
+            actual.ProducerConsumerCollectionItems.Should().HaveCount(3);
+            actual.ProducerConsumerCollectionItems.Should().BeOfType<System.Collections.Concurrent.ConcurrentBag<Widget>>();
             actual.DictionaryItems.Should().HaveCount(3);
             actual.SortedDictionaryItems.Should().HaveCount(3);
             actual.SortedListItems.Should().HaveCount(3);

--- a/ModelBuilder.IntegrationTests/MappingTests.cs
+++ b/ModelBuilder.IntegrationTests/MappingTests.cs
@@ -30,5 +30,14 @@ namespace ModelBuilder.IntegrationTests
             actual.Engine.Should().NotBeNull();
             actual.Engine.Should().BeOfType<DieselEngine>();
         }
+
+        [Fact]
+        public void CreatePopulatesInterfaceMemberUsingNonGenericMapping()
+        {
+            var actual = Model.Mapping(typeof(IEngine), typeof(DieselEngine)).Create<Vehicle>();
+
+            actual.Engine.Should().NotBeNull();
+            actual.Engine.Should().BeOfType<DieselEngine>();
+        }
     }
 }

--- a/ModelBuilder.IntegrationTests/Models/Box.cs
+++ b/ModelBuilder.IntegrationTests/Models/Box.cs
@@ -1,0 +1,12 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A plain, user-defined generic class with no BCL collection shape, used to verify closed
+    ///     constructed generic types (for example <c>Box&lt;Widget&gt;</c>) build like any other class -
+    ///     both as a root and as a nested member - independent of any mapping registration.
+    /// </summary>
+    public class Box<T>
+    {
+        public T? Value { get; set; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/BoxHolder.cs
+++ b/ModelBuilder.IntegrationTests/Models/BoxHolder.cs
@@ -1,0 +1,11 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A class with a closed generic member (<c>Box&lt;Widget&gt;</c>) built with no mapping
+    ///     registration, proving generic member resolution works on its own.
+    /// </summary>
+    public class BoxHolder
+    {
+        public Box<Widget>? Item { get; set; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/CollectionsProfile.cs
+++ b/ModelBuilder.IntegrationTests/Models/CollectionsProfile.cs
@@ -33,6 +33,8 @@ namespace ModelBuilder.IntegrationTests.Models
 
         public ConcurrentStack<Widget> ConcurrentStackItems { get; set; } = new();
 
+        public IProducerConsumerCollection<Widget> ProducerConsumerCollectionItems { get; set; } = new ConcurrentBag<Widget>();
+
         public Dictionary<string, Widget> DictionaryItems { get; set; } = new();
 
         public SortedDictionary<string, Widget> SortedDictionaryItems { get; set; } = new();

--- a/ModelBuilder.IntegrationTests/Models/IRepository.cs
+++ b/ModelBuilder.IntegrationTests/Models/IRepository.cs
@@ -1,0 +1,13 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     An open generic abstraction with no default concrete type, used to verify
+    ///     <c>Model.Mapping(typeof(IRepository&lt;&gt;), typeof(Repository&lt;&gt;))</c> resolves any closed
+    ///     shape of it (paired with an explicit closed <c>Mapping&lt;,&gt;()</c> declaration) to a fully
+    ///     built concrete instance.
+    /// </summary>
+    public interface IRepository<T>
+    {
+        T? Item { get; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/IntegrationTestModule.cs
+++ b/ModelBuilder.IntegrationTests/Models/IntegrationTestModule.cs
@@ -3,8 +3,8 @@ namespace ModelBuilder.IntegrationTests.Models
     using System;
 
     /// <summary>
-    ///     A reusable <see cref="IConfigurationModule" /> bundling a mapping, an ignore rule, an
-    ///     <c>IgnoringAny</c> predicate and an option override, so
+    ///     A reusable <see cref="IConfigurationModule" /> bundling a mapping, an open generic mapping, an
+    ///     ignore rule, an <c>IgnoringAny</c> predicate and an option override, so
     ///     <c>Model.UsingModule&lt;IntegrationTestModule&gt;()</c> can be verified end to end.
     /// </summary>
     public sealed class IntegrationTestModule : IConfigurationModule
@@ -13,6 +13,9 @@ namespace ModelBuilder.IntegrationTests.Models
         public void Configure(IBuildConfiguration configuration)
         {
             configuration.AddMapping<IEngine, DieselEngine>();
+
+            configuration.AddMapping(typeof(IRepository<>), typeof(Repository<>));
+            configuration.AddMapping<IRepository<Widget>, Repository<Widget>>();
 
             configuration.Ignore(typeof(Credentials), nameof(Credentials.Password));
 

--- a/ModelBuilder.IntegrationTests/Models/Repository.cs
+++ b/ModelBuilder.IntegrationTests/Models/Repository.cs
@@ -1,0 +1,11 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     The concrete, generic <see cref="IRepository{T}" /> implementation mapped in the open generic
+    ///     mapping scenario tests.
+    /// </summary>
+    public class Repository<T> : IRepository<T>
+    {
+        public T? Item { get; set; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/Models/RepositoryHolder.cs
+++ b/ModelBuilder.IntegrationTests/Models/RepositoryHolder.cs
@@ -1,0 +1,12 @@
+namespace ModelBuilder.IntegrationTests.Models
+{
+    /// <summary>
+    ///     A class with a closed, generic interface-typed member that has no default concrete type,
+    ///     requiring an open generic mapping registration (plus a closed shape declaration) for the build
+    ///     to populate it.
+    /// </summary>
+    public class RepositoryHolder
+    {
+        public IRepository<Widget>? Repository { get; set; }
+    }
+}

--- a/ModelBuilder.IntegrationTests/OpenGenericMappingTests.cs
+++ b/ModelBuilder.IntegrationTests/OpenGenericMappingTests.cs
@@ -1,0 +1,55 @@
+namespace ModelBuilder.IntegrationTests
+{
+    using FluentAssertions;
+    using ModelBuilder.IntegrationTests.Models;
+    using Xunit;
+
+    /// <summary>
+    ///     End-to-end tests of open generic type mapping via
+    ///     <c>Model.Mapping(typeof(IRepository&lt;&gt;), typeof(Repository&lt;&gt;))</c>, and of closed
+    ///     constructed generic types building like any other class independent of any mapping.
+    /// </summary>
+    public class OpenGenericMappingTests
+    {
+        [Fact]
+        public void CreatePopulatesClosedGenericInterfaceMemberUsingOpenGenericMapping()
+        {
+            var actual = Model.Mapping(typeof(IRepository<>), typeof(Repository<>))
+                .Mapping<IRepository<Widget>, Repository<Widget>>()
+                .Create<RepositoryHolder>();
+
+            actual.Repository.Should().NotBeNull();
+            actual.Repository.Should().BeOfType<Repository<Widget>>();
+            actual.Repository!.Item.Should().NotBeNull();
+            actual.Repository.Item!.Name.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public void CreatePopulatesClosedGenericInterfaceMemberUsingOpenGenericMappingConfiguredByModule()
+        {
+            var actual = Model.UsingModule<IntegrationTestModule>().Create<RepositoryHolder>();
+
+            actual.Repository.Should().NotBeNull();
+            actual.Repository.Should().BeOfType<Repository<Widget>>();
+        }
+
+        [Fact]
+        public void CreateBuildsClosedGenericTypeAsRootWithNoMappingRegistered()
+        {
+            var actual = Model.Create<Box<Widget>>();
+
+            actual.Value.Should().NotBeNull();
+            actual.Value!.Name.Should().NotBeNullOrWhiteSpace();
+        }
+
+        [Fact]
+        public void CreateBuildsClosedGenericMemberWithNoMappingRegistered()
+        {
+            var actual = Model.Create<BoxHolder>();
+
+            actual.Item.Should().NotBeNull();
+            actual.Item!.Value.Should().NotBeNull();
+            actual.Item.Value!.Name.Should().NotBeNullOrWhiteSpace();
+        }
+    }
+}

--- a/ModelBuilder.UnitTests/BuildConfigurationTests.cs
+++ b/ModelBuilder.UnitTests/BuildConfigurationTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace ModelBuilder.UnitTests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using FluentAssertions;
     using ModelBuilder;
@@ -37,6 +38,48 @@
             Action action = () => sut.AddMapping(null!, typeof(MemoryStream));
 
             action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void TryGetMappingConstructsClosedTargetFromOpenGenericMapping()
+        {
+            var sut = new BuildConfiguration();
+
+            sut.AddMapping(typeof(IList<>), typeof(List<>));
+
+            sut.TryGetMapping(typeof(IList<int>), out var target).Should().BeTrue();
+            target.Should().Be(typeof(List<int>));
+        }
+
+        [Fact]
+        public void TryGetMappingPrefersExactClosedMappingOverOpenGenericMapping()
+        {
+            var sut = new BuildConfiguration();
+
+            sut.AddMapping(typeof(IList<>), typeof(List<>));
+            sut.AddMapping(typeof(IList<int>), typeof(CustomIntList));
+
+            sut.TryGetMapping(typeof(IList<int>), out var target).Should().BeTrue();
+            target.Should().Be(typeof(CustomIntList));
+        }
+
+        [Fact]
+        public void TryGetMappingReturnsRegisteredClosedTargetForOpenGenericSource()
+        {
+            var sut = new BuildConfiguration();
+
+            sut.AddMapping(typeof(IList<>), typeof(CustomIntList));
+
+            sut.TryGetMapping(typeof(IList<int>), out var target).Should().BeTrue();
+            target.Should().Be(typeof(CustomIntList));
+        }
+
+        [Fact]
+        public void TryGetMappingReturnsFalseWhenOpenGenericSourceHasNoMapping()
+        {
+            var sut = new BuildConfiguration();
+
+            sut.TryGetMapping(typeof(IList<int>), out _).Should().BeFalse();
         }
 
         [Fact]
@@ -146,6 +189,10 @@
             var sut = new BuildConfiguration();
 
             sut.TryGetMapping(typeof(Stream), out _).Should().BeFalse();
+        }
+
+        private class CustomIntList : List<int>
+        {
         }
     }
 }

--- a/ModelBuilder.UnitTests/ModelConfigurationTests.cs
+++ b/ModelBuilder.UnitTests/ModelConfigurationTests.cs
@@ -118,6 +118,16 @@
         }
 
         [Fact]
+        public void MappingByTypeReturnsSameConfigurationForChaining()
+        {
+            var sut = new ModelConfiguration();
+
+            var actual = sut.Mapping(typeof(IThing), typeof(Thing));
+
+            actual.Should().BeSameAs(sut);
+        }
+
+        [Fact]
         public void PopulateInvokesLogSinkWhenWriteLogConfigured()
         {
             ModelBuilderSlot<Probe>.Instance = new ProbeBuilder();

--- a/ModelBuilder.UnitTests/ModelFacadeTests.cs
+++ b/ModelBuilder.UnitTests/ModelFacadeTests.cs
@@ -119,6 +119,30 @@
             }
         }
 
+        [Fact]
+        public void MappingGenericReturnsConfiguration()
+        {
+            var actual = global::ModelBuilder.Model.Mapping<IThing, Thing>();
+
+            actual.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void MappingByTypeReturnsConfiguration()
+        {
+            var actual = global::ModelBuilder.Model.Mapping(typeof(IThing), typeof(Thing));
+
+            actual.Should().NotBeNull();
+        }
+
+        private interface IThing
+        {
+        }
+
+        private sealed class Thing : IThing
+        {
+        }
+
         private sealed class Unregistered
         {
         }

--- a/ModelBuilder/BuildConfiguration.cs
+++ b/ModelBuilder/BuildConfiguration.cs
@@ -137,7 +137,32 @@ namespace ModelBuilder
         {
             sourceType = sourceType ?? throw new ArgumentNullException(nameof(sourceType));
 
-            return _typeMappings.TryGetValue(sourceType, out targetType!);
+            if (_typeMappings.TryGetValue(sourceType, out targetType!))
+            {
+                return true;
+            }
+
+            // A mapping registered against an open generic source (for example
+            // AddMapping(typeof(IRepository<>), typeof(Repository<>))) has no exact dictionary entry
+            // for a closed member type such as IRepository<Widget>. Fall back to the source's open
+            // generic definition and, when the registered target is itself open, construct the closed
+            // target from the same type arguments. The closed target still needs its own generated
+            // builder (registered via Model.RegistryInternal) to actually resolve a value - this only
+            // fixes the type lookup, not builder discovery.
+            if (sourceType.IsGenericType
+                && sourceType.IsGenericTypeDefinition == false
+                && _typeMappings.TryGetValue(sourceType.GetGenericTypeDefinition(), out var openTarget))
+            {
+                targetType = openTarget.IsGenericTypeDefinition
+                    ? openTarget.MakeGenericType(sourceType.GetGenericArguments())
+                    : openTarget;
+
+                return true;
+            }
+
+            targetType = null!;
+
+            return false;
         }
 
         /// <inheritdoc />

--- a/ModelBuilder/IBuildConfiguration.cs
+++ b/ModelBuilder/IBuildConfiguration.cs
@@ -19,6 +19,14 @@ namespace ModelBuilder
         /// <exception cref="ArgumentNullException">
         ///     The <paramref name="sourceType" /> or <paramref name="targetType" /> parameter is <c>null</c>.
         /// </exception>
+        /// <remarks>
+        ///     <paramref name="sourceType" /> and <paramref name="targetType" /> may both be open generic type
+        ///     definitions (for example <c>typeof(IRepository&lt;&gt;)</c> mapped to <c>typeof(Repository&lt;&gt;)</c>),
+        ///     in which case a closed member type is resolved against the source's generic type definition and
+        ///     the matching closed target is constructed from the same type arguments. The closed target type
+        ///     still needs its own generated builder to be reachable in the build graph for a value to be
+        ///     produced.
+        /// </remarks>
         IBuildConfiguration AddMapping(Type sourceType, Type targetType);
 
         /// <summary>
@@ -111,6 +119,11 @@ namespace ModelBuilder
         /// <param name="sourceType">The source type to resolve.</param>
         /// <param name="targetType">The mapped concrete type, when one is registered.</param>
         /// <returns><c>true</c> if a mapping is registered; otherwise, <c>false</c>.</returns>
+        /// <remarks>
+        ///     When <paramref name="sourceType" /> is a closed generic type with no exact mapping, this falls
+        ///     back to a mapping registered against its open generic type definition and constructs the closed
+        ///     target from <paramref name="sourceType" />'s type arguments.
+        /// </remarks>
         bool TryGetMapping(Type sourceType, out Type targetType);
 
         /// <summary>

--- a/ModelBuilder/IModelConfiguration.cs
+++ b/ModelBuilder/IModelConfiguration.cs
@@ -57,6 +57,23 @@ namespace ModelBuilder
             where TTarget : TSource;
 
         /// <summary>
+        ///     Adds a type mapping from a source type to a concrete target type.
+        /// </summary>
+        /// <param name="sourceType">The source type, typically an interface or abstract type.</param>
+        /// <param name="targetType">The concrete type to build in its place.</param>
+        /// <returns>The same configuration for chaining.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The <paramref name="sourceType" /> or <paramref name="targetType" /> parameter is <c>null</c>.
+        /// </exception>
+        /// <remarks>
+        ///     <paramref name="sourceType" /> and <paramref name="targetType" /> may both be open generic type
+        ///     definitions, letting one mapping serve every closed shape at build time. Declare each closed
+        ///     shape you need built with its own <see cref="Mapping{TSource, TTarget}" /> (or this overload with
+        ///     closed types) call.
+        /// </remarks>
+        IModelConfiguration Mapping(Type sourceType, Type targetType);
+
+        /// <summary>
         ///     Begins a typed construction of <typeparamref name="T" /> using this configuration. Supply
         ///     constructor arguments through the generated <c>From</c> extension method on the returned
         ///     handle.

--- a/ModelBuilder/Model.cs
+++ b/ModelBuilder/Model.cs
@@ -126,6 +126,27 @@ namespace ModelBuilder
         }
 
         /// <summary>
+        ///     Begins a configured build that maps a source type to a concrete target type.
+        /// </summary>
+        /// <param name="sourceType">The source type, typically an interface or abstract type.</param>
+        /// <param name="targetType">The concrete type to build in its place.</param>
+        /// <returns>A configuration to continue building.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///     The <paramref name="sourceType" /> or <paramref name="targetType" /> parameter is <c>null</c>.
+        /// </exception>
+        /// <remarks>
+        ///     <paramref name="sourceType" /> and <paramref name="targetType" /> may both be open generic type
+        ///     definitions (for example <c>typeof(IRepository&lt;&gt;)</c> mapped to <c>typeof(Repository&lt;&gt;)</c>),
+        ///     letting one mapping serve every closed shape at build time. The generator still needs to see a
+        ///     closed shape to generate a builder for it - declare each closed shape you need with its own
+        ///     <see cref="Mapping{TSource, TTarget}" /> (or this overload with closed types) call.
+        /// </remarks>
+        public static IModelConfiguration Mapping(Type sourceType, Type targetType)
+        {
+            return new ModelConfiguration().Mapping(sourceType, targetType);
+        }
+
+        /// <summary>
         ///     Begins a typed construction of <typeparamref name="T" />. Supply constructor arguments
         ///     through the generated <c>From</c> extension method on the returned handle, for example
         ///     <c>Model.Construct&lt;Person&gt;().From("Fred", "Smith")</c>.

--- a/ModelBuilder/ModelConfiguration.cs
+++ b/ModelBuilder/ModelConfiguration.cs
@@ -69,6 +69,14 @@ namespace ModelBuilder
         }
 
         /// <inheritdoc />
+        public IModelConfiguration Mapping(Type sourceType, Type targetType)
+        {
+            _configuration.AddMapping(sourceType, targetType);
+
+            return this;
+        }
+
+        /// <inheritdoc />
         public Construction<T> Construct<T>()
         {
             return new Construction<T>(_configuration, _logSink);

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ discovered at compile time and gets a dedicated builder, so ModelBuilder:
   * [Typed construction](#typed-construction)
   * [Ignoring members](#ignoring-members)
   * [Mapping abstract and interface types](#mapping-abstract-and-interface-types)
+    + [Open generic type mapping](#open-generic-type-mapping)
   * [Custom value sources](#custom-value-sources)
     + [Writing a reusable value source](#writing-a-reusable-value-source)
     + [The build context seams](#the-build-context-seams)
@@ -244,6 +245,28 @@ var payload = Model.Mapping<IShipment, GroundShipment>().Create<Parcel>();
 There is no automatic assembly scan that guesses a concrete type — the mapping is explicit, which is
 what keeps the build deterministic and reflection-free.
 
+#### Open generic type mapping
+
+`Model.Mapping(Type, Type)` accepts open generic type definitions, registering a mapping that applies
+to every closed shape of the source at runtime:
+
+```csharp
+var payload = Model.Mapping(typeof(IRepository<>), typeof(Repository<>))
+    .Mapping<IRepository<Widget>, Repository<Widget>>()
+    .Create<Holder>();
+```
+
+The open mapping only registers the **runtime fallback** used when no exact closed mapping matches a
+requested type. It does not, by itself, make the compiler generate a builder for any particular closed
+shape — you still declare each closed shape you need built, exactly as with a non-generic mapping (a
+`Model.Mapping<TClosedSource, TClosedTarget>()`/`Model.Mapping(typeof(TClosedSource), typeof(TClosedTarget))`
+call for that shape). The generator reports two diagnostics to help catch mistakes:
+
+| Diagnostic | Meaning |
+| --- | --- |
+| `MB1006` | An open generic mapping's target has no accessible constructor, so no closed shape of it could ever be built. |
+| `MB1007` | An open generic mapping is registered but never paired with a closed `Mapping<,>()` declaration, so no builder will ever be generated for any of its closed shapes. |
+
 ### Custom value sources
 
 When the built-in data does not produce what your model needs, register a custom value source. A
@@ -413,8 +436,9 @@ builder when it is reachable from one of these triggers:
 1. **`Model.Create<T>()`, `Model.Populate<T>()`, `Model.Construct<T>()` or `Model.Create(typeof(T))`** —
    `T` and everything reachable from it (constructor parameters and public settable properties) become
    buildable. This covers almost everything with no annotations.
-2. **`Model.Mapping<TSource, TTarget>()`** — makes `TTarget` buildable for abstract/interface
-   members.
+2. **`Model.Mapping<TSource, TTarget>()` / `Model.Mapping(Type, Type)`** — makes `TTarget` buildable
+   for abstract/interface members. The non-generic overload also accepts an [open generic type
+   definition](#open-generic-type-mapping) pair (`typeof(IRepository<>)`, `typeof(Repository<>)`).
 3. **`[GenerateModelBuilder]`** — names a root that is only ever built polymorphically or via a
    runtime `Type`.
 
@@ -432,6 +456,8 @@ diagnostic**, not a runtime exception:
 | `MB1001` | The requested root type cannot have a builder generated (for example it is abstract, an interface, or has no accessible constructor — a supported collection shape such as `List<T>` or `Dictionary<K,V>` is buildable even though it's generic). |
 | `MB1002` | The root type is inaccessible (for example `private`) to the generated code. |
 | `MB1005` | A `Model.Create(typeof(X))` root could not be resolved to a buildable type. |
+| `MB1006` | An open generic [`Model.Mapping(Type, Type)`](#open-generic-type-mapping) target has no accessible constructor. |
+| `MB1007` | An open generic [`Model.Mapping(Type, Type)`](#open-generic-type-mapping) is never paired with a closed `Mapping<,>()` declaration. |
 | `MB1011` | The discovered collection is a shape ModelBuilder does not build (for example `ArraySegment<T>` or a live view like `Dictionary<K,V>.KeyCollection`). |
 
 ### GenerateModelBuilder

--- a/design.md
+++ b/design.md
@@ -421,6 +421,18 @@ Keep only what real usage needs:
   Kept; this is the main customization seam used in practice.
 - **Ignore rules** — both targeted and type-agnostic (§8.1).
 - **Type mapping** — `Mapping<TSource,TTarget>()`, validated at compile time.
+  `Model.Mapping(Type, Type)` / `IBuildConfiguration.AddMapping(Type, Type)` also accept an open
+  generic source/target pair (for example `Model.Mapping(typeof(IRepository<>), typeof(Repository<>))`):
+  at runtime, `IBuildConfiguration.TryGetMapping` falls back from a closed member type to its open
+  generic definition and constructs the matching closed target via `MakeGenericType`. The generator
+  discovers open mapping declarations (`GetRootType`'s `"Mapping"` branch, both `typeof()` arguments
+  unbound) separately from ordinary roots, but does **not** infer which closed shapes to build from an
+  open declaration alone — each closed shape still needs its own explicit
+  `Mapping<TClosedSource, TClosedTarget>()` (or `Mapping(typeof(TClosedSource), typeof(TClosedTarget))`)
+  declaration to become a build root, exactly like a non-generic mapping. Two diagnostics guard this:
+  `MB1006` (the open mapping's target has no accessible constructor — no closed shape could ever be
+  built) and `MB1007` (the open mapping is never paired with a closed `Mapping<,>()` declaration — no
+  builder will ever be generated for any closed shape of it).
 - **Value overrides** — `BuildOptions` (collection counts, null frequency, max depth), tuned through
   `Model.SetOptions(x => …)` / `IBuildConfiguration.SetOptions(x => …)`, replacing the open-ended
   `UpdateValueGenerator<T>`/`UpdateTypeCreator<T>` reflection-tuning. Per-member overrides (e.g. an
@@ -967,7 +979,7 @@ root, constructor parameter, or settable member of any of the following shapes g
 | `SortedDictionary<K,V>` | — |
 | `SortedList<K,V>` | — |
 | `ConcurrentDictionary<K,V>` | — |
-| `ConcurrentBag<T>` | — |
+| `ConcurrentBag<T>` | `IProducerConsumerCollection<T>` |
 | `ConcurrentQueue<T>` | — |
 | `ConcurrentStack<T>` | — |
 | `ReadOnlyCollection<T>` | — |
@@ -981,6 +993,19 @@ root, constructor parameter, or settable member of any of the following shapes g
 | `ImmutableSortedDictionary<K,V>` | — |
 | `ImmutableQueue<T>` | `IImmutableQueue<T>` |
 | `ImmutableStack<T>` | `IImmutableStack<T>` |
+
+**Interface ownership.** Several kinds above share BCL interfaces that are already reachable
+through a sibling kind (for example `Queue<T>`, `Stack<T>`, `SortedSet<T>` and `Collection<T>` all
+implement `IEnumerable<T>`/`ICollection<T>`/`IReadOnlyCollection<T>`, already owned by `List<T>`;
+`SortedSet<T>` also implements `ISet<T>`/`IReadOnlySet<T>`, already owned by `HashSet<T>`;
+`ImmutableSortedSet<T>` also implements `IImmutableSet<T>`, already owned by `ImmutableHashSet<T>`).
+Requesting a shared interface always resolves to its owning kind; a kind never listed with an
+interface target in the table above has no interface of its own reachable in the build graph — only
+its concrete type resolves to it. `IProducerConsumerCollection<T>` is the one exception: it is
+implemented by `ConcurrentBag<T>`, `ConcurrentQueue<T>` and `ConcurrentStack<T>` alike, a genuine
+three-way ambiguity with no existing owner, so it defaults to `ConcurrentBag<T>` — the same
+"first/simplest concrete kind wins" rule `ImmutableHashSet<T>` already follows for `IImmutableSet<T>`
+over `ImmutableSortedSet<T>`.
 
 **User-defined collection types.** A concrete, accessible, non-abstract type with a public
 parameterless constructor that either derives from one of the mutable Add-based or keyed kinds


### PR DESCRIPTION
## Summary

Closes #399.

- Adds `Model.Mapping(Type sourceType, Type targetType)` / `IModelConfiguration.Mapping(Type, Type)` supporting **open generic type mappings** (e.g. `typeof(IRepository<>), typeof(Repository<>)`), with a runtime `MakeGenericType` fallback used when no exact closed mapping matches a requested type.
- Each closed shape you need built must still be declared explicitly (e.g. `Mapping<IRepository<Widget>, Repository<Widget>>()`) — the open mapping alone only registers the runtime fallback, it does not make the generator emit a builder for any particular shape.
- Two new diagnostics: `MB1006` (open mapping's target has no accessible constructor) and `MB1007` (an open mapping is never paired with a closed `Mapping<,>()` declaration).
- Fixes a separate, pre-existing bug in `BuildGraphWalker.IsBuildable` that excluded **all** generic types, even fully closed constructed ones (e.g. `Repository<Widget>`) — closed generic types now build correctly as both roots and nested members, independent of any mapping.
- Adds `System.Collections.Concurrent.IProducerConsumerCollection<T>` to the recognized collection interface shapes (resolves to `ConcurrentBag<T>`).

## Testing

- New generator execution tests (open mapping success + MB1006 + MB1007, closed generic type as root/member).
- New unit tests for the `Model.Mapping(Type, Type)`/`ModelConfiguration.Mapping(Type, Type)` facade and the open-generic runtime fallback.
- New `ModelBuilder.IntegrationTests` end-to-end coverage: fluent and module-based open generic mapping, closed generic type building with no mapping, non-generic `Mapping(Type, Type)` overload equivalence, `IProducerConsumerCollection<T>` population.
- `README.md` and `design.md` updated.
- Full solution build: 0 warnings/errors. Full test suite: 1335/1335 passing.
