### PR TITLE
v9: Report a diagnostic when a member resolves to an unmapped abstract or interface type

### DIFF
--- a/ModelBuilder.Generator.UnitTests/ModelBuilderGeneratorTests.cs
+++ b/ModelBuilder.Generator.UnitTests/ModelBuilderGeneratorTests.cs
@@ -317,6 +317,88 @@ namespace Sample
         }
 
         [Fact]
+        public void ReportsMB1012ForUnmappedAbstractMember()
+        {
+            const string source = @"
+namespace Sample
+{
+    public interface IEngine
+    {
+        int Horsepower { get; set; }
+    }
+
+    public sealed class Car
+    {
+        public IEngine? Engine { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Car Build() => global::ModelBuilder.Model.Create<Car>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+
+            harness.GeneratorDiagnostics.Should().Contain(d => d.Id == "MB1012");
+        }
+
+        [Fact]
+        public void DoesNotReportMB1012ForMappedAbstractMember()
+        {
+            const string source = @"
+namespace Sample
+{
+    public interface IEngine
+    {
+        int Horsepower { get; set; }
+    }
+
+    public sealed class V8Engine : IEngine
+    {
+        public int Horsepower { get; set; }
+    }
+
+    public sealed class Car
+    {
+        public IEngine? Engine { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Car Build() =>
+            global::ModelBuilder.Model.Mapping<IEngine, V8Engine>().Create<Car>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+
+            harness.GeneratorDiagnostics.Should().NotContain(d => d.Id == "MB1012");
+        }
+
+        [Fact]
+        public void DoesNotReportMB1012ForRecognizedCollectionInterfaceMember()
+        {
+            const string source = @"
+namespace Sample
+{
+    public sealed class Car
+    {
+        public System.Collections.Generic.IList<int>? Parts { get; set; }
+    }
+
+    public static class Caller
+    {
+        public static Car Build() => global::ModelBuilder.Model.Create<Car>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+
+            harness.GeneratorDiagnostics.Should().NotContain(d => d.Id == "MB1012");
+        }
+
+        [Fact]
         public void DoesNotReportDiagnosticsForBuildableRoot()
         {
             const string source = @"

--- a/ModelBuilder.Generator/AnalyzerReleases.Unshipped.md
+++ b/ModelBuilder.Generator/AnalyzerReleases.Unshipped.md
@@ -11,3 +11,4 @@ MB1005  | ModelBuilder | Warning | Model.Create(typeof(X)) names a type that can
 MB1006  | ModelBuilder | Warning | Open generic mapping target has no accessible constructor
 MB1007  | ModelBuilder | Warning | Open generic mapping is never used in closed form
 MB1011  | ModelBuilder | Warning | Discovered collection shape is not supported
+MB1012  | ModelBuilder | Warning | Member resolves to an unmapped abstract or interface type

--- a/ModelBuilder.Generator/BuildGraphWalker.cs
+++ b/ModelBuilder.Generator/BuildGraphWalker.cs
@@ -25,6 +25,9 @@ namespace ModelBuilder.Generator
                 SymbolDisplayFormat.FullyQualifiedFormat.MiscellaneousOptions
                 | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier);
 
+        private static readonly HashSet<INamedTypeSymbol> _emptyKnownMappedSources =
+            new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+
         /// <summary>
         ///     Determines whether the type has a public constructor the generated code can call.
         /// </summary>
@@ -56,16 +59,21 @@ namespace ModelBuilder.Generator
 
         public static GenerationModel Walk(IEnumerable<INamedTypeSymbol> roots)
         {
-            return Walk(roots, out _);
+            return Walk(roots, _emptyKnownMappedSources, out _, out _);
         }
 
-        public static GenerationModel Walk(IEnumerable<INamedTypeSymbol> roots, out ImmutableArray<string> unsupportedCollectionShapes)
+        public static GenerationModel Walk(
+            IEnumerable<INamedTypeSymbol> roots,
+            HashSet<INamedTypeSymbol> knownMappedSources,
+            out ImmutableArray<string> unsupportedCollectionShapes,
+            out ImmutableArray<string> unmappedMemberTypes)
         {
             var discovered = new Dictionary<string, INamedTypeSymbol>();
             var enums = new Dictionary<string, INamedTypeSymbol>();
             var nullables = new SortedSet<string>(System.StringComparer.Ordinal);
             var collections = new Dictionary<string, ITypeSymbol>();
             var unsupported = new HashSet<string>();
+            var unmapped = new HashSet<string>();
             var queue = new Queue<INamedTypeSymbol>();
             var seen = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
 
@@ -93,12 +101,12 @@ namespace ModelBuilder.Generator
 
                     if (rootElement != null)
                     {
-                        Visit(rootElement, queue, seen, nullables, collections, unsupported);
+                        Visit(rootElement, queue, seen, nullables, collections, unsupported, knownMappedSources, unmapped);
                     }
 
                     if (rootValue != null)
                     {
-                        Visit(rootValue, queue, seen, nullables, collections, unsupported);
+                        Visit(rootValue, queue, seen, nullables, collections, unsupported, knownMappedSources, unmapped);
                     }
 
                     continue;
@@ -120,12 +128,12 @@ namespace ModelBuilder.Generator
 
                 foreach (var parameter in SelectConstructor(type)?.Parameters ?? ImmutableArray<IParameterSymbol>.Empty)
                 {
-                    Visit(parameter.Type, queue, seen, nullables, collections, unsupported);
+                    Visit(parameter.Type, queue, seen, nullables, collections, unsupported, knownMappedSources, unmapped);
                 }
 
                 foreach (var property in GetSettableProperties(type))
                 {
-                    Visit(property.Type, queue, seen, nullables, collections, unsupported);
+                    Visit(property.Type, queue, seen, nullables, collections, unsupported, knownMappedSources, unmapped);
                 }
             }
 
@@ -153,6 +161,7 @@ namespace ModelBuilder.Generator
             }
 
             unsupportedCollectionShapes = unsupported.OrderBy(name => name, System.StringComparer.Ordinal).ToImmutableArray();
+            unmappedMemberTypes = unmapped.OrderBy(name => name, System.StringComparer.Ordinal).ToImmutableArray();
 
             return new GenerationModel(
                 new EquatableArray<BuildableModel>(builders.ToImmutable()),
@@ -267,7 +276,9 @@ namespace ModelBuilder.Generator
             HashSet<INamedTypeSymbol> seen,
             SortedSet<string> nullables,
             Dictionary<string, ITypeSymbol> collections,
-            HashSet<string> unsupported)
+            HashSet<string> unsupported,
+            HashSet<INamedTypeSymbol> knownMappedSources,
+            HashSet<string> unmappedMemberTypes)
         {
             if (type is IArrayTypeSymbol array)
             {
@@ -277,7 +288,7 @@ namespace ModelBuilder.Generator
 
                     collections[arraySlotName] = type;
 
-                    Visit(array.ElementType, queue, seen, nullables, collections, unsupported);
+                    Visit(array.ElementType, queue, seen, nullables, collections, unsupported, knownMappedSources, unmappedMemberTypes);
                 }
 
                 return;
@@ -295,7 +306,7 @@ namespace ModelBuilder.Generator
 
                 nullables.Add(underlying.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat));
 
-                Visit(underlying, queue, seen, nullables, collections, unsupported);
+                Visit(underlying, queue, seen, nullables, collections, unsupported, knownMappedSources, unmappedMemberTypes);
 
                 return;
             }
@@ -308,12 +319,12 @@ namespace ModelBuilder.Generator
 
                 if (element != null)
                 {
-                    Visit(element, queue, seen, nullables, collections, unsupported);
+                    Visit(element, queue, seen, nullables, collections, unsupported, knownMappedSources, unmappedMemberTypes);
                 }
 
                 if (value != null)
                 {
-                    Visit(value, queue, seen, nullables, collections, unsupported);
+                    Visit(value, queue, seen, nullables, collections, unsupported, knownMappedSources, unmappedMemberTypes);
                 }
 
                 return;
@@ -321,6 +332,17 @@ namespace ModelBuilder.Generator
 
             if (named.IsGenericType && IsUnsupportedCollectionShape(named))
             {
+                return;
+            }
+
+            if ((named.TypeKind == TypeKind.Interface || named.IsAbstract)
+                && knownMappedSources.Contains(named.OriginalDefinition) == false)
+            {
+                // Neither a recognized collection shape nor a type with a Mapping<,> registered anywhere
+                // in the compilation - the generator has nothing concrete to build here, and the member
+                // would otherwise be silently left at its default value with zero signal as to why.
+                unmappedMemberTypes.Add(named.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat));
+
                 return;
             }
 

--- a/ModelBuilder.Generator/DiagnosticDescriptors.cs
+++ b/ModelBuilder.Generator/DiagnosticDescriptors.cs
@@ -63,5 +63,14 @@ namespace ModelBuilder.Generator
             DiagnosticSeverity.Warning,
             isEnabledByDefault: true,
             helpLinkUri: "https://github.com/roryprimrose/ModelBuilder");
+
+        public static readonly DiagnosticDescriptor UnmappedAbstractMember = new DiagnosticDescriptor(
+            "MB1012",
+            "Member resolves to an unmapped abstract or interface type",
+            "'{0}' is abstract or an interface and appears as a member type with no Mapping<,> to a concrete type, so it will be left at its default value wherever it is used. Add Model.Mapping<{0}, TConcrete>() to give it a concrete type.",
+            Category,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: "https://github.com/roryprimrose/ModelBuilder");
     }
 }

--- a/ModelBuilder.Generator/ModelBuilderGenerator.cs
+++ b/ModelBuilder.Generator/ModelBuilderGenerator.cs
@@ -113,12 +113,22 @@ namespace ModelBuilder.Generator
                 return;
             }
 
-            var models = BuildGraphWalker.Walk(distinct.Values, out var unsupportedCollectionShapes);
+            var models = BuildGraphWalker.Walk(
+                distinct.Values,
+                closedMappingSourceDefinitions,
+                out var unsupportedCollectionShapes,
+                out var unmappedMemberTypes);
 
             foreach (var unsupportedShape in unsupportedCollectionShapes)
             {
                 context.ReportDiagnostic(
                     Diagnostic.Create(DiagnosticDescriptors.UnsupportedCollectionShape, Location.None, unsupportedShape));
+            }
+
+            foreach (var unmappedMemberType in unmappedMemberTypes)
+            {
+                context.ReportDiagnostic(
+                    Diagnostic.Create(DiagnosticDescriptors.UnmappedAbstractMember, Location.None, unmappedMemberType));
             }
 
             if (models.IsEmpty)

--- a/ModelBuilder.UnitTests/BuildContextTests.cs
+++ b/ModelBuilder.UnitTests/BuildContextTests.cs
@@ -218,6 +218,21 @@
             log.Entries[0].Children[0].MemberName.Should().Be("Name");
         }
 
+        [Fact]
+        public void BuildReturnsDefaultAndWritesSkipMemberLogWhenNoBuilderIsRegistered()
+        {
+            var log = new BuildLog();
+            var sut = new BuildContext(new RandomSource(1), log);
+
+            var result = sut.Build<Customer>(typeof(Order), "Customer");
+
+            result.Should().BeNull();
+            log.Entries.Should().ContainSingle();
+            log.Entries[0].Kind.Should().Be(BuildLogEntryKind.SkipMember);
+            log.Entries[0].MemberName.Should().Be("Customer");
+            log.Entries[0].Reason.Should().Be("no builder registered");
+        }
+
         private sealed class Customer
         {
         }

--- a/ModelBuilder/BuildContext.cs
+++ b/ModelBuilder/BuildContext.cs
@@ -317,6 +317,8 @@ namespace ModelBuilder
 
             if (builder == null)
             {
+                Log.Write(BuildLogEntryKind.SkipMember, memberType, memberName, "no builder registered", collectionIndex);
+
                 return default!;
             }
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ var payload = Model.Mapping<IShipment, GroundShipment>().Create<Parcel>();
 ```
 
 There is no automatic assembly scan that guesses a concrete type — the mapping is explicit, which is
-what keeps the build deterministic and reflection-free.
+what keeps the build deterministic and reflection-free. This applies whether the abstract/interface
+type is the root you asked to build (`MB1001`) or a member reached along the way (`MB1012`) — either
+way, without a mapping the value is left at its default rather than built.
 
 #### Open generic type mapping
 
@@ -459,6 +461,7 @@ diagnostic**, not a runtime exception:
 | `MB1006` | An open generic [`Model.Mapping(Type, Type)`](#open-generic-type-mapping) target has no accessible constructor. |
 | `MB1007` | An open generic [`Model.Mapping(Type, Type)`](#open-generic-type-mapping) is never paired with a closed `Mapping<,>()` declaration. |
 | `MB1011` | The discovered collection is a shape ModelBuilder does not build (for example `ArraySegment<T>` or a live view like `Dictionary<K,V>.KeyCollection`). |
+| `MB1012` | A *member* (not a root) resolves to an abstract or interface type with no `Mapping<,>` to a concrete type, so it is silently left at its default value wherever it is used. |
 
 ### GenerateModelBuilder
 

--- a/design.md
+++ b/design.md
@@ -1586,12 +1586,13 @@ runs. Indicative catalogue (IDs illustrative, severities tunable via `.editorcon
 | `MB1003` | Error | A value-ordering cycle (`.Before(...)`) has no valid topological order (§8.2.6) | "Remove or invert one `.Before(...)` in the cycle `{a → b → … → a}`." |
 | `MB1004` | Error | `.ForMembersMatching(expr)` uses a lambda shape the generator can't interpret (§8.2.8) | "Use a supported expression (`EndsWith`/`StartsWith`/`Contains`/`==`/`&&`/`||`/`!`) or switch to `.When(...)` for runtime evaluation." |
 | `MB1005` | Warning | `Model.Create(typeof(X))` names a constant type that can't be built (unbuildable/inaccessible/unmapped) (§12.7) | "`{X}` has no generated builder — make it discoverable (`Create<{X}>()`, a mapping, or `[GenerateModelBuilder]`)." |
-| `MB1006` | Warning | A `[GenerateModelBuilder]` attribute is declared on a **production** type rather than in the test assembly (§6.1) | "Move to `[assembly: GenerateModelBuilder(typeof({X}))]` in the test project to avoid shipping the attribute." |
-| `MB1007` | Warning | Two sources match the same target with equal priority (ambiguous selection) | "Give one source a higher priority, or narrow its `.ForMembers...` constraint." |
+| `MB1006` | Warning | An open generic `Model.Mapping(typeof(TSource<>), typeof(TTarget<>))` target has no accessible constructor for any closed shape (§8.2, #399) | "Add an accessible constructor to `{target}`, or narrow the mapping to shapes that have one." |
+| `MB1007` | Warning | An open generic mapping is registered but never paired with a closed `Model.Mapping<TSource, TTarget>()` declaration, so no builder is ever generated for it (§8.2, #399) | "Add `Model.Mapping<TClosedSource, TClosedTarget>()` for each closed shape you need built." |
 | `MB1008` | Warning | A registered `IValueSource<T>` is never selected (dead registration) | "Remove the registration or widen its match; it currently matches no discovered member." |
 | `MB1009` | Info | A member falls back to runtime matching via `.When(...)` on a hot path | "Express the condition with `.ForMembersNamed/Matching(...)` to compile it in, if possible." |
 | `MB1010` | Error | A write-only or init-only member is targeted in a way that can't be satisfied (§7, #282) | "Remove the member from population, or provide it via constructor args." |
 | `MB1011` | Warning | A discovered collection is a shape ModelBuilder does not build (no mutator, or a live view) (§8.2) | "Add `Model.Mapping<,>` to a supported collection, or register a custom `IValueSource<{X}>`." |
+| `MB1012` | Warning | A discovered *member* (not a root) resolves to an abstract/interface type with no `Mapping<,>` to a concrete type, so it is silently left at its default value (#400) | "Add `Model.Mapping<{abstract}, {concrete}>()` to give `{abstract}` a concrete type." |
 
 The generator also emits the **cycle** and **ambiguity** errors against the *merged* configuration
 for the whole compilation, so a conflict introduced by combining two modules is caught (§8.2.6).


### PR DESCRIPTION
Closes #400

An abstract/interface **root** type with no `Mapping<,>` already reports `MB1001`, but the same type reached as a **member** (constructor parameter or settable property) was silently left at its default value with no signal at all.

## Changes

- New diagnostic `MB1012` (`UnmappedAbstractMember`, Warning): reported when a discovered member resolves to an interface/abstract type that isn't a recognized collection shape and has no `Mapping<,>` to a concrete type anywhere in the compilation.
- `BuildGraphWalker`: threads the set of known mapped source types through `Walk`/`Visit` and records unmapped interface/abstract member types encountered while walking the graph. Recognized collection interfaces (e.g. `IList<T>`) are classified earlier and are unaffected.
- `ModelBuilderGenerator`: reports `MB1012` for each unmapped member type found, reusing the mapping-source information already collected for the existing open-generic-mapping diagnostics.
- `BuildContext`: the runtime fallback that previously silently returned `default` when no builder was registered for a member now also writes a `SkipMember` log entry ("no builder registered"), matching the existing circular-reference/depth guard logging.
- `README.md` / `design.md` updated: new `MB1012` row in the diagnostics tables, a clarifying note that the mapping requirement applies to both roots and members, and the previously-stale `MB1006`/`MB1007` catalogue rows in `design.md` corrected to match their actual (post-#399) meaning.

## Testing

- New generator diagnostic tests: `MB1012` fires for an unmapped interface member, does not fire once a `Mapping<,>()` is registered, and does not fire for a recognized collection-interface member.
- New runtime test asserting the `SkipMember` log entry for the "no builder registered" case.
- Full solution build: 0 warnings/errors. `dotnet test ModelBuilder.slnx`: 1341/1341 passing.
