### PR TITLE
Add built-in Exception value source

### DIFF
--- a/ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs
+++ b/ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs
@@ -33,6 +33,7 @@
             yield return new object[] { typeof(Uri) };
             yield return new object[] { typeof(Version) };
             yield return new object[] { typeof(byte[]) };
+            yield return new object[] { typeof(Exception) };
         }
 
         [Theory]
@@ -111,6 +112,19 @@
 
             actual.Should().NotBeNull();
             actual!.Length.Should().BeInRange(1, 16);
+        }
+
+        [Fact]
+        public void ExceptionSourceProducesInvalidOperationExceptionWithMessage()
+        {
+            var context = new BuildContext(new RandomSource(42));
+
+            context.TryResolveValueSource<Exception>(out var source).Should().BeTrue();
+
+            var actual = source!.Create(context, new BuildTarget(typeof(Exception)));
+
+            actual.Should().BeOfType<InvalidOperationException>();
+            actual.Message.Should().NotBeNullOrEmpty();
         }
 
         [Fact]

--- a/ModelBuilder/BuiltInValueSources.cs
+++ b/ModelBuilder/BuiltInValueSources.cs
@@ -111,6 +111,7 @@
             registry.Register<Uri>(new DelegateValueSource<Uri>(NextUri));
             registry.Register<Version>(new DelegateValueSource<Version>(NextVersion));
             registry.Register<byte[]>(new DelegateValueSource<byte[]>(NextBytes));
+            registry.Register<Exception>(new DelegateValueSource<Exception>(NextException));
 
             return registry;
         }
@@ -282,6 +283,13 @@
             context.Random.NextBytes(buffer);
 
             return buffer;
+        }
+
+        private static Exception NextException(IBuildContext context)
+        {
+            var message = NextString(context);
+
+            return new InvalidOperationException(message);
         }
 
         private static DateTime NextDateTime(IBuildContext context)

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ override — starts from these defaults. A module, or a fluent call on `Model`, 
 | Type mappings | None. Abstract and interface members are unbuildable until you add a [`Mapping<,>`](#mapping-abstract-and-interface-types). |
 | Ignore rules | None. Every settable member and constructor parameter is populated. |
 | Custom value sources | None registered, but the **built-in value sources always apply** (you never register them, and a custom source only overrides the built-in for its type/name). |
-| Built-in typed sources | `bool`; every numeric type (`byte`/`sbyte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double`/`decimal`); `char`; `string`; `Guid`; `DateTime`; `DateTimeOffset`; `TimeSpan`; `Uri`; `Version`; `byte[]`. Enums, nullables and collections are handled by the generator. |
+| Built-in typed sources | `bool`; every numeric type (`byte`/`sbyte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double`/`decimal`); `char`; `string`; `Guid`; `DateTime`; `DateTimeOffset`; `TimeSpan`; `Uri`; `Version`; `byte[]`; `Exception` (produces `InvalidOperationException` with a random message). Enums, nullables and collections are handled by the generator. |
 | Built-in named sources | The entity-style member-name sources in [Built-in data](#entity-style-data-matched-by-member-name) (names, email, company, location fields, age, date of birth, …). |
 | Build options | `MinCount` 1, `MaxCount` 10, `NullPercentage` 5, `MaxDepth` 50, `UseConstructorDefaults` off, `RetainAssignedValues` off — see [Tuning the build](#tuning-the-build). |
 
@@ -746,8 +746,8 @@ excludes matched members from the generated population code at compile time.
 ## Built-in data
 
 ModelBuilder ships value sources for the common primitive and BCL types (`bool`, the numeric types,
-`char`, `string`, `Guid`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Uri`, `Version`, `byte[]`),
-plus enum, nullable and collection support that the generator wires up automatically.
+`char`, `string`, `Guid`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Uri`, `Version`, `byte[]`,
+`Exception`), plus enum, nullable and collection support that the generator wires up automatically.
 
 ### Entity-style data matched by member name
 


### PR DESCRIPTION
## Summary

Registers a built-in `DelegateValueSource<Exception>` in the value source registry that produces `InvalidOperationException` instances with a random message string.

This removes the need for consumers to declare a custom `IValueSource<Exception>` workaround whenever a type has an `Exception` constructor parameter or settable member.

## Changes

- **ModelBuilder/BuiltInValueSources.cs**: Added `Exception` registration to `CreateRegistry()` and a `NextException` helper method
- **ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs**: Added test and theory data for `Exception` type

## Behavior

- `Model.Create<SomeType>()` where `SomeType` has an `Exception` member now produces an `InvalidOperationException` with a random message
- Consumers can still override with their own `IValueSource<Exception>` or `Mapping<Exception, T>` if needed

Closes #407