### PR TITLE
Add built-in object-to-string value source

### DIFF
--- a/ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs
+++ b/ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs
@@ -116,7 +116,6 @@
         }
 
         [Fact]
-<<<<<<< HEAD
         public void ExceptionSourceProducesInvalidOperationExceptionWithMessage()
         {
             var context = new BuildContext(new RandomSource(42));
@@ -127,7 +126,9 @@
 
             actual.Should().BeOfType<InvalidOperationException>();
             actual.Message.Should().NotBeNullOrEmpty();
-=======
+        }
+
+        [Fact]
         public void ObjectSourceProducesStringValue()
         {
             var context = new BuildContext(new RandomSource(42));
@@ -138,7 +139,6 @@
 
             actual.Should().BeOfType<string>();
             ((string)actual).Should().NotBeNullOrEmpty();
->>>>>>> a1bcecc (Add built-in object value source mapped to string)
         }
 
         [Fact]

--- a/ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs
+++ b/ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs
@@ -34,6 +34,7 @@
             yield return new object[] { typeof(Version) };
             yield return new object[] { typeof(byte[]) };
             yield return new object[] { typeof(Exception) };
+            yield return new object[] { typeof(object) };
         }
 
         [Theory]
@@ -115,6 +116,7 @@
         }
 
         [Fact]
+<<<<<<< HEAD
         public void ExceptionSourceProducesInvalidOperationExceptionWithMessage()
         {
             var context = new BuildContext(new RandomSource(42));
@@ -125,6 +127,18 @@
 
             actual.Should().BeOfType<InvalidOperationException>();
             actual.Message.Should().NotBeNullOrEmpty();
+=======
+        public void ObjectSourceProducesStringValue()
+        {
+            var context = new BuildContext(new RandomSource(42));
+
+            context.TryResolveValueSource<object>(out var source).Should().BeTrue();
+
+            var actual = source!.Create(context, new BuildTarget(typeof(object)));
+
+            actual.Should().BeOfType<string>();
+            ((string)actual).Should().NotBeNullOrEmpty();
+>>>>>>> a1bcecc (Add built-in object value source mapped to string)
         }
 
         [Fact]

--- a/ModelBuilder/BuiltInValueSources.cs
+++ b/ModelBuilder/BuiltInValueSources.cs
@@ -112,6 +112,7 @@
             registry.Register<Version>(new DelegateValueSource<Version>(NextVersion));
             registry.Register<byte[]>(new DelegateValueSource<byte[]>(NextBytes));
             registry.Register<Exception>(new DelegateValueSource<Exception>(NextException));
+            registry.Register<object>(new DelegateValueSource<object>(c => NextString(c)));
 
             return registry;
         }

--- a/README.md
+++ b/README.md
@@ -666,7 +666,7 @@ override — starts from these defaults. A module, or a fluent call on `Model`, 
 | Type mappings | None. Abstract and interface members are unbuildable until you add a [`Mapping<,>`](#mapping-abstract-and-interface-types). |
 | Ignore rules | None. Every settable member and constructor parameter is populated. |
 | Custom value sources | None registered, but the **built-in value sources always apply** (you never register them, and a custom source only overrides the built-in for its type/name). |
-| Built-in typed sources | `bool`; every numeric type (`byte`/`sbyte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double`/`decimal`); `char`; `string`; `Guid`; `DateTime`; `DateTimeOffset`; `TimeSpan`; `Uri`; `Version`; `byte[]`; `Exception` (produces `InvalidOperationException` with a random message). Enums, nullables and collections are handled by the generator. |
+| Built-in typed sources | `bool`; every numeric type (`byte`/`sbyte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double`/`decimal`); `char`; `string`; `Guid`; `DateTime`; `DateTimeOffset`; `TimeSpan`; `Uri`; `Version`; `byte[]`; `Exception` (produces `InvalidOperationException` with a random message); `object` (produces a random string). Enums, nullables and collections are handled by the generator. |
 | Built-in named sources | The entity-style member-name sources in [Built-in data](#entity-style-data-matched-by-member-name) (names, email, company, location fields, age, date of birth, …). |
 | Build options | `MinCount` 1, `MaxCount` 10, `NullPercentage` 5, `MaxDepth` 50, `UseConstructorDefaults` off, `RetainAssignedValues` off — see [Tuning the build](#tuning-the-build). |
 
@@ -747,7 +747,8 @@ excludes matched members from the generated population code at compile time.
 
 ModelBuilder ships value sources for the common primitive and BCL types (`bool`, the numeric types,
 `char`, `string`, `Guid`, `DateTime`, `DateTimeOffset`, `TimeSpan`, `Uri`, `Version`, `byte[]`,
-`Exception`), plus enum, nullable and collection support that the generator wires up automatically.
+`Exception`, `object`), plus enum, nullable and collection support that the generator wires up
+automatically. `object` produces a random string — the most pragmatic default for a typeless slot.
 
 ### Entity-style data matched by member name
 


### PR DESCRIPTION
## Summary

Registers a built-in `DelegateValueSource<object>` in the value source registry that produces a random string value.

This makes all of the following work out of the box without requiring `Mapping<object, string>`:

- `Model.Create<object>()` → returns a random string
- `Model.Create<List<object>>()` → returns a list of random strings
- `Model.Create<IDictionary<string, object>>()` → returns a dictionary with string values
- Any type with an `object` member → populated with a random string

## Rationale

- `object` has no meaningful properties to populate, so `new object()` is rarely useful for test data
- Mapping to `string` is the most pragmatic default — strings are serializable, loggable, and comparable
- Consumers can still override with their own `IValueSource<object>` or `Mapping<object, T>` if needed

## Changes

- **ModelBuilder/BuiltInValueSources.cs**: Added `object` registration to `CreateRegistry()`
- **ModelBuilder.UnitTests/BuiltInValueSourcesTests.cs**: Added test and theory data for `object` type

Closes #409