### PR TITLE
Add built-in mappings for common BCL collection interfaces

### DIFF
--- a/ModelBuilder.Generator.UnitTests/ModelBuilderGeneratorTests.cs
+++ b/ModelBuilder.Generator.UnitTests/ModelBuilderGeneratorTests.cs
@@ -293,6 +293,64 @@ namespace Sample
         }
 
         [Fact]
+        public void DoesNotReportMB1001ForBuiltInCollectionInterfaceRoot()
+        {
+            const string source = @"
+namespace Sample
+{
+    public static class Caller
+    {
+        public static System.Collections.Generic.IList<int> Build()
+            => global::ModelBuilder.Model.Create<System.Collections.Generic.IList<int>>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+
+            harness.GeneratorDiagnostics.Should().NotContain(d => d.Id == "MB1001");
+            harness.CompilationErrors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void DoesNotReportMB1001ForBuiltInDictionaryInterfaceRoot()
+        {
+            const string source = @"
+namespace Sample
+{
+    public static class Caller
+    {
+        public static System.Collections.Generic.IDictionary<string, int> Build()
+            => global::ModelBuilder.Model.Create<System.Collections.Generic.IDictionary<string, int>>();
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+
+            harness.GeneratorDiagnostics.Should().NotContain(d => d.Id == "MB1001");
+            harness.CompilationErrors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void DoesNotReportMB1001ForBuiltInCollectionInterfaceTypeOfRoot()
+        {
+            const string source = @"
+namespace Sample
+{
+    public static class Caller
+    {
+        public static object Build()
+            => global::ModelBuilder.Model.Create(typeof(System.Collections.Generic.ISet<int>));
+    }
+}";
+
+            var harness = GeneratorTestHarness.Run(source);
+
+            harness.GeneratorDiagnostics.Should().NotContain(d => d.Id == "MB1001");
+            harness.GeneratorDiagnostics.Should().NotContain(d => d.Id == "MB1005");
+            harness.CompilationErrors.Should().BeEmpty();
+        }
+
+        [Fact]
         public void ReportsMB1002ForRootWithoutAccessibleConstructor()
         {
             const string source = @"

--- a/ModelBuilder.Generator/ModelBuilderGenerator.cs
+++ b/ModelBuilder.Generator/ModelBuilderGenerator.cs
@@ -306,13 +306,18 @@ namespace ModelBuilder.Generator
                     && containingType == ModelTypeName
                     && TryGetTypeOfArgument(invocation, context.SemanticModel, token, 0, out var constantType))
                 {
-                    return new RootCapture(constantType, invocation.GetLocation(), isTypeOfRoot: true);
+                    return new RootCapture(
+                        ResolveBuiltInMapping(constantType, context.SemanticModel.Compilation),
+                        invocation.GetLocation(),
+                        isTypeOfRoot: true);
                 }
 
                 return default;
             }
 
-            return new RootCapture(method.TypeArguments[0] as INamedTypeSymbol, invocation.GetLocation());
+            return new RootCapture(
+                ResolveBuiltInMapping(method.TypeArguments[0] as INamedTypeSymbol, context.SemanticModel.Compilation),
+                invocation.GetLocation());
         }
 
         private static bool TryGetTypeOfArgument(
@@ -396,6 +401,62 @@ namespace ModelBuilder.Generator
             }
 
             return ImmutableArray<RootCapture>.Empty;
+        }
+
+        private static INamedTypeSymbol? ResolveBuiltInMapping(INamedTypeSymbol? symbol, Compilation compilation)
+        {
+            if (symbol is null
+                || symbol.TypeKind != TypeKind.Interface
+                || !symbol.IsGenericType
+                || symbol.IsUnboundGenericType)
+            {
+                return symbol;
+            }
+
+            var definition = symbol.OriginalDefinition;
+            var targetMetadataName = GetBuiltInMappingTarget(definition);
+
+            if (targetMetadataName is null)
+            {
+                return symbol;
+            }
+
+            var concreteDefinition = compilation.GetTypeByMetadataName(targetMetadataName);
+
+            if (concreteDefinition is null)
+            {
+                return symbol;
+            }
+
+            return concreteDefinition.Construct(symbol.TypeArguments.ToArray());
+        }
+
+        private static string? GetBuiltInMappingTarget(INamedTypeSymbol definition)
+        {
+            if (definition.ContainingNamespace?.ToDisplayString() != "System.Collections.Generic")
+            {
+                return null;
+            }
+
+            switch (definition.MetadataName)
+            {
+                case "IDictionary`2":
+                case "IReadOnlyDictionary`2":
+                    return "System.Collections.Generic.Dictionary`2";
+
+                case "IList`1":
+                case "IReadOnlyList`1":
+                case "IReadOnlyCollection`1":
+                case "ICollection`1":
+                case "IEnumerable`1":
+                    return "System.Collections.Generic.List`1";
+
+                case "ISet`1":
+                    return "System.Collections.Generic.HashSet`1";
+
+                default:
+                    return null;
+            }
         }
 
         private readonly struct RootCapture

--- a/ModelBuilder.IntegrationTests/CustomCollectionTests.cs
+++ b/ModelBuilder.IntegrationTests/CustomCollectionTests.cs
@@ -1,5 +1,6 @@
 namespace ModelBuilder.IntegrationTests
 {
+    using System.Collections.Generic;
     using FluentAssertions;
     using ModelBuilder.IntegrationTests.Models;
     using Xunit;
@@ -51,6 +52,63 @@ namespace ModelBuilder.IntegrationTests
 
             actual.Should().HaveCount(2);
             actual.Should().OnlyContain(w => w.Name != string.Empty);
+        }
+
+        [Fact]
+        public void CreateBuildsListFromIListInterfaceRoot()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 2;
+                    x.MaxCount = 2;
+                })
+                .Create<IList<string>>();
+
+            actual.Should().BeOfType<List<string>>();
+            actual.Should().HaveCount(2);
+            actual.Should().OnlyContain(s => !string.IsNullOrEmpty(s));
+        }
+
+        [Fact]
+        public void CreateBuildsDictionaryFromIDictionaryInterfaceRoot()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 2;
+                    x.MaxCount = 2;
+                })
+                .Create<IDictionary<string, int>>();
+
+            actual.Should().BeOfType<Dictionary<string, int>>();
+            actual.Should().HaveCount(2);
+        }
+
+        [Fact]
+        public void CreateBuildsHashSetFromISetInterfaceRoot()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 2;
+                    x.MaxCount = 2;
+                })
+                .Create<ISet<int>>();
+
+            actual.Should().BeOfType<HashSet<int>>();
+            actual.Should().HaveCountGreaterThanOrEqualTo(2);
+        }
+
+        [Fact]
+        public void CreateBuildsListFromIReadOnlyListInterfaceRoot()
+        {
+            var actual = Model.SetOptions(x =>
+                {
+                    x.MinCount = 2;
+                    x.MaxCount = 2;
+                })
+                .Create<IReadOnlyList<int>>();
+
+            actual.Should().BeOfType<List<int>>();
+            actual.Should().HaveCount(2);
         }
     }
 }

--- a/ModelBuilder.UnitTests/BuildConfigurationTests.cs
+++ b/ModelBuilder.UnitTests/BuildConfigurationTests.cs
@@ -79,7 +79,7 @@
         {
             var sut = new BuildConfiguration();
 
-            sut.TryGetMapping(typeof(IList<int>), out _).Should().BeFalse();
+            sut.TryGetMapping(typeof(IComparable<int>), out _).Should().BeFalse();
         }
 
         [Fact]
@@ -189,6 +189,34 @@
             var sut = new BuildConfiguration();
 
             sut.TryGetMapping(typeof(Stream), out _).Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(typeof(IReadOnlyDictionary<string, int>), typeof(Dictionary<string, int>))]
+        [InlineData(typeof(IDictionary<string, int>), typeof(Dictionary<string, int>))]
+        [InlineData(typeof(IReadOnlyList<int>), typeof(List<int>))]
+        [InlineData(typeof(IReadOnlyCollection<int>), typeof(List<int>))]
+        [InlineData(typeof(IList<int>), typeof(List<int>))]
+        [InlineData(typeof(ICollection<int>), typeof(List<int>))]
+        [InlineData(typeof(IEnumerable<int>), typeof(List<int>))]
+        [InlineData(typeof(ISet<int>), typeof(HashSet<int>))]
+        public void TryGetMappingResolvesBuiltInCollectionInterfaceMapping(Type source, Type expectedTarget)
+        {
+            var sut = new BuildConfiguration();
+
+            sut.TryGetMapping(source, out var target).Should().BeTrue();
+            target.Should().Be(expectedTarget);
+        }
+
+        [Fact]
+        public void TryGetMappingPrefersUserMappingOverBuiltIn()
+        {
+            var sut = new BuildConfiguration();
+
+            sut.AddMapping(typeof(IList<>), typeof(CustomIntList));
+
+            sut.TryGetMapping(typeof(IList<int>), out var target).Should().BeTrue();
+            target.Should().Be(typeof(CustomIntList));
         }
 
         private class CustomIntList : List<int>

--- a/ModelBuilder/BuildConfiguration.cs
+++ b/ModelBuilder/BuildConfiguration.cs
@@ -10,6 +10,18 @@ namespace ModelBuilder
     /// </summary>
     internal sealed class BuildConfiguration : IBuildConfiguration
     {
+        private static readonly Dictionary<Type, Type> _builtInMappings = new Dictionary<Type, Type>
+        {
+            { typeof(IReadOnlyDictionary<,>), typeof(Dictionary<,>) },
+            { typeof(IDictionary<,>), typeof(Dictionary<,>) },
+            { typeof(IReadOnlyList<>), typeof(List<>) },
+            { typeof(IReadOnlyCollection<>), typeof(List<>) },
+            { typeof(IList<>), typeof(List<>) },
+            { typeof(ICollection<>), typeof(List<>) },
+            { typeof(IEnumerable<>), typeof(List<>) },
+            { typeof(ISet<>), typeof(HashSet<>) },
+        };
+
         private readonly HashSet<MemberKey> _ignoredMembers = new HashSet<MemberKey>();
         private readonly List<Func<MemberSignature, bool>> _ignorePredicates = new List<Func<MemberSignature, bool>>();
         private readonly Dictionary<Type, Type> _typeMappings = new Dictionary<Type, Type>();
@@ -150,14 +162,27 @@ namespace ModelBuilder
             // builder (registered via Model.RegistryInternal) to actually resolve a value - this only
             // fixes the type lookup, not builder discovery.
             if (sourceType.IsGenericType
-                && sourceType.IsGenericTypeDefinition == false
-                && _typeMappings.TryGetValue(sourceType.GetGenericTypeDefinition(), out var openTarget))
+                && sourceType.IsGenericTypeDefinition == false)
             {
-                targetType = openTarget.IsGenericTypeDefinition
-                    ? openTarget.MakeGenericType(sourceType.GetGenericArguments())
-                    : openTarget;
+                var definition = sourceType.GetGenericTypeDefinition();
 
-                return true;
+                if (_typeMappings.TryGetValue(definition, out var openTarget))
+                {
+                    targetType = openTarget.IsGenericTypeDefinition
+                        ? openTarget.MakeGenericType(sourceType.GetGenericArguments())
+                        : openTarget;
+
+                    return true;
+                }
+
+                // Fall back to built-in mappings for common BCL collection interfaces so consumers
+                // do not need to declare the same obvious mappings in every project.
+                if (_builtInMappings.TryGetValue(definition, out var builtInTarget))
+                {
+                    targetType = builtInTarget.MakeGenericType(sourceType.GetGenericArguments());
+
+                    return true;
+                }
             }
 
             targetType = null!;

--- a/ModelBuilder/BuildContext.cs
+++ b/ModelBuilder/BuildContext.cs
@@ -254,6 +254,20 @@ namespace ModelBuilder
                         return (T)Invoke(memberName, () => mappedBuilder.Create(this));
                     }
                 }
+
+                if (Model.HasValueSourceFactory(mappedType))
+                {
+                    using (Log.BeginScope(BuildLogEntryKind.CreateValue, mappedType, memberName, "mapped value source", collectionIndex))
+                    using (EnterMember(declaringType, memberName, mappedType, collectionIndex))
+                    {
+                        return (T)Invoke(memberName, () =>
+                        {
+                            Model.TryCreateFromValueSourceFactory(mappedType, this, out var result);
+
+                            return result!;
+                        });
+                    }
+                }
             }
 
             // Custom value sources registered on the build configuration take precedence over the

--- a/ModelBuilder/Model.cs
+++ b/ModelBuilder/Model.cs
@@ -286,6 +286,21 @@ namespace ModelBuilder
                 {
                     return value;
                 }
+
+                // Fall back to built-in type mappings (e.g. IList<> → List<>) so collection
+                // interfaces resolve without requiring the caller to declare them.
+                if (context.Configuration.TryGetMapping(typeof(T), out var mappedType))
+                {
+                    if (_registry.TryGet(mappedType, out var mappedBuilder) && mappedBuilder != null)
+                    {
+                        return (T)mappedBuilder.Create(context);
+                    }
+
+                    if (_valueSourceFactories.TryGetValue(mappedType, out var mappedFactory))
+                    {
+                        return (T)mappedFactory(context)!;
+                    }
+                }
             }
 
             throw NoBuilder(typeof(T));

--- a/ModelBuilder/Model.cs
+++ b/ModelBuilder/Model.cs
@@ -44,6 +44,21 @@ namespace ModelBuilder
                 {
                     return builtInValue!;
                 }
+
+                // Fall back to built-in type mappings (e.g. IReadOnlyDictionary<,> → Dictionary<,>)
+                // so collection interfaces resolve without requiring the caller to declare them.
+                if (context.Configuration.TryGetMapping(instanceType, out var mappedType))
+                {
+                    if (_registry.TryGet(mappedType, out var mappedBuilder) && mappedBuilder != null)
+                    {
+                        return mappedBuilder.Create(context);
+                    }
+
+                    if (_valueSourceFactories.TryGetValue(mappedType, out var mappedFactory))
+                    {
+                        return mappedFactory(context)!;
+                    }
+                }
             }
 
             throw NoBuilder(instanceType);
@@ -336,5 +351,40 @@ namespace ModelBuilder
         ///     public contract).
         /// </summary>
         internal static ModelBuilderRegistry RegistryInternal => _registry;
+
+        /// <summary>
+        ///     Attempts to create a value for the specified type using a registered value-source
+        ///     factory. Used by <see cref="BuildContext" /> when a type mapping resolves to a
+        ///     type that has a value source but no model builder (common for collections).
+        /// </summary>
+        /// <param name="type">The type to create a value for.</param>
+        /// <param name="context">The build context.</param>
+        /// <param name="value">The created value, when a factory exists.</param>
+        /// <returns><c>true</c> if a factory was found and invoked; otherwise, <c>false</c>.</returns>
+        internal static bool TryCreateFromValueSourceFactory(Type type, IBuildContext context, out object? value)
+        {
+            if (_valueSourceFactories.TryGetValue(type, out var factory))
+            {
+                value = factory(context);
+
+                return true;
+            }
+
+            value = null;
+
+            return false;
+        }
+
+        /// <summary>
+        ///     Returns whether a value-source factory is registered for the specified type, without
+        ///     invoking it. Used by <see cref="BuildContext" /> to test resolution before entering a
+        ///     build frame.
+        /// </summary>
+        /// <param name="type">The type to check.</param>
+        /// <returns><c>true</c> if a factory is registered; otherwise, <c>false</c>.</returns>
+        internal static bool HasValueSourceFactory(Type type)
+        {
+            return _valueSourceFactories.ContainsKey(type);
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -250,7 +250,15 @@ way, without a mapping the value is left at its default rather than built.
 The common BCL collection interfaces (`IList<>`, `ICollection<>`, `IEnumerable<>`,
 `IReadOnlyList<>`, `IReadOnlyCollection<>`, `IDictionary<,>`, `IReadOnlyDictionary<,>`, `ISet<>`)
 have built-in mappings to their obvious concrete counterparts and do not require explicit
-declarations.
+declarations — whether they appear as a member type or as the root of a `Model.Create<T>()` call:
+
+```csharp
+// As a root — creates a populated List<string> returned as IList<string>:
+var names = Model.Create<IList<string>>();
+
+// As a member — the property is populated with a Dictionary<string, int>:
+var order = Model.Create<Order>(); // Order.Metadata is IDictionary<string, int>
+```
 
 #### Open generic type mapping
 

--- a/README.md
+++ b/README.md
@@ -247,6 +247,11 @@ what keeps the build deterministic and reflection-free. This applies whether the
 type is the root you asked to build (`MB1001`) or a member reached along the way (`MB1012`) — either
 way, without a mapping the value is left at its default rather than built.
 
+The common BCL collection interfaces (`IList<>`, `ICollection<>`, `IEnumerable<>`,
+`IReadOnlyList<>`, `IReadOnlyCollection<>`, `IDictionary<,>`, `IReadOnlyDictionary<,>`, `ISet<>`)
+have built-in mappings to their obvious concrete counterparts and do not require explicit
+declarations.
+
 #### Open generic type mapping
 
 `Model.Mapping(Type, Type)` accepts open generic type definitions, registering a mapping that applies
@@ -663,7 +668,7 @@ override — starts from these defaults. A module, or a fluent call on `Model`, 
 
 | Category | Default |
 | --- | --- |
-| Type mappings | None. Abstract and interface members are unbuildable until you add a [`Mapping<,>`](#mapping-abstract-and-interface-types). |
+| Type mappings | Built-in for common BCL collection interfaces (`IReadOnlyDictionary<,>` → `Dictionary<,>`, `IDictionary<,>` → `Dictionary<,>`, `IReadOnlyList<>` / `IReadOnlyCollection<>` / `IList<>` / `ICollection<>` / `IEnumerable<>` → `List<>`, `ISet<>` → `HashSet<>`). Other abstract and interface members are unbuildable until you add a [`Mapping<,>`](#mapping-abstract-and-interface-types). |
 | Ignore rules | None. Every settable member and constructor parameter is populated. |
 | Custom value sources | None registered, but the **built-in value sources always apply** (you never register them, and a custom source only overrides the built-in for its type/name). |
 | Built-in typed sources | `bool`; every numeric type (`byte`/`sbyte`/`short`/`ushort`/`int`/`uint`/`long`/`ulong`/`float`/`double`/`decimal`); `char`; `string`; `Guid`; `DateTime`; `DateTimeOffset`; `TimeSpan`; `Uri`; `Version`; `byte[]`; `Exception` (produces `InvalidOperationException` with a random message); `object` (produces a random string). Enums, nullables and collections are handled by the generator. |


### PR DESCRIPTION
## Summary

Adds built-in open-generic type mappings for the common BCL collection interfaces so consumers no longer need to declare the same obvious `Mapping<,>` declarations in every project.

## Built-in mappings

| Interface | Concrete type |
|---|---|
| `IReadOnlyDictionary<,>` | `Dictionary<,>` |
| `IDictionary<,>` | `Dictionary<,>` |
| `IReadOnlyList<>` | `List<>` |
| `IReadOnlyCollection<>` | `List<>` |
| `IList<>` | `List<>` |
| `ICollection<>` | `List<>` |
| `IEnumerable<>` | `List<>` |
| `ISet<>` | `HashSet<>` |

## Changes

- **ModelBuilder/BuildConfiguration.cs**: Added a static `_builtInMappings` dictionary and a fallback check in `TryGetMapping` after user-declared mappings
- **ModelBuilder/BuildContext.cs**: Enhanced `BuildCore<T>`'s mapping handler to also check value source factories for the mapped type (needed because collections are registered as value sources, not model builders)
- **ModelBuilder/Model.cs**: Added `TryCreateFromValueSourceFactory` and `HasValueSourceFactory` internal methods; added mapping fallback to `Create(Type)` for the non-generic path
- **ModelBuilder.UnitTests/BuildConfigurationTests.cs**: Added theory tests for all 8 built-in mappings, user-mapping-takes-precedence test, and updated existing test to use a non-collection interface

## Behavior

- User-declared mappings always take precedence over built-in mappings
- When a collection interface member maps to a concrete type that has a registered value source factory (from generated code), the value source is now invoked correctly
- `Model.Create(Type)` with a collection interface type now resolves through the mapping fallback

Closes #408