### PR TITLE
Switch NuGet.org publishing to OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,8 +157,7 @@ jobs:
     # Run on pushes to the base repository for the default branch (main) or a version tagged build.
     # Main builds are untagged and GitVersion stamps them as a beta pre-release (see GitVersion.yml),
     # so they publish pre-release packages; version tags publish the stable release.
-    # TEMPORARY: also run on trusted-publishing-nuget branch to test OIDC flow.
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/trusted-publishing-nuget' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'dependabot[bot]'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'dependabot[bot]'
 
     steps:
     

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,11 +146,14 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
+    environment: production
     # action-gh-release needs contents: write to create the GitHub release; the GitHub Packages push
-    # below authenticates with the built-in GITHUB_TOKEN, which needs packages: write.
+    # below authenticates with the built-in GITHUB_TOKEN, which needs packages: write; id-token: write
+    # allows the NuGet/login OIDC token exchange for trusted publishing.
     permissions:
       contents: write
       packages: write
+      id-token: write
     # Run on pushes to the base repository for the default branch (main) or a version tagged build.
     # Main builds are untagged and GitVersion stamps them as a beta pre-release (see GitVersion.yml),
     # so they publish pre-release packages; version tags publish the stable release.
@@ -190,10 +193,14 @@ jobs:
         GPR_APIKEY: ${{ secrets.GITHUB_TOKEN }}
       run: dotnet nuget push "*.symbols.nupkg" --api-key "$GPR_APIKEY" --source https://nuget.pkg.github.com/roryprimrose/index.json --skip-duplicate
       
+    - name: NuGet login (OIDC trusted publishing)
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: rprimrose
+
     - name: Publish to NuGet.org
-      env: 
-        NUGET_APIKEY: ${{ secrets.NUGET_APIKEY }}
-      run: dotnet nuget push "*.symbols.nupkg" --api-key "$NUGET_APIKEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push "*.symbols.nupkg" --api-key "${{ steps.nuget-login.outputs.NUGET_API_KEY }}" --source https://api.nuget.org/v3/index.json --skip-duplicate
 
     - name: Create release and upload assets
       # Only create a GitHub release for an explicit version tag; main pre-release builds publish the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,8 @@ jobs:
     # Run on pushes to the base repository for the default branch (main) or a version tagged build.
     # Main builds are untagged and GitVersion stamps them as a beta pre-release (see GitVersion.yml),
     # so they publish pre-release packages; version tags publish the stable release.
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'dependabot[bot]'
+    # TEMPORARY: also run on trusted-publishing-nuget branch to test OIDC flow.
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/trusted-publishing-nuget' || startsWith(github.ref, 'refs/tags/v')) && github.actor != 'dependabot[bot]'
 
     steps:
     


### PR DESCRIPTION
## Summary

Replaces the long-lived `NUGET_APIKEY` secret with NuGet's Trusted Publishing OIDC flow for publishing packages to nuget.org.

## Changes

- Added `environment: production` to the `release` job (matching the trusted publishing policy on nuget.org)
- Added `id-token: write` permission to enable GitHub OIDC token issuance
- Added `NuGet/login@v1` step to exchange the OIDC token for a short-lived NuGet API key
- Removed the `NUGET_APIKEY` secret reference from the publish step

## Benefits

- No long-lived API key to rotate or risk leaking
- Short-lived credentials (1 hour) scoped to the specific workflow run
- Publishing is locked to this specific repository, workflow file, and environment